### PR TITLE
Ported to coq v8.9

### DIFF
--- a/src/aac_rewrite.ml
+++ b/src/aac_rewrite.ml
@@ -147,7 +147,7 @@ let by_aac_reflexivity zero
       (* This convert is required to deal with evars in a proper
 	 way *)
       let convert_to = mkApp (r, [| mkApp (eval,[| t |]); mkApp (eval, [|t'|])|])   in
-      let convert = Proofview.V82.of_tactic (Tactics.convert_concl convert_to Term.VMcast) in
+      let convert = Proofview.V82.of_tactic (Tactics.convert_concl convert_to Constr.VMcast) in
       let apply_tac = Proofview.V82.of_tactic (Tactics.apply decision_thm) in
       (Tacticals.tclTHENLIST
 	 [ retype decision_thm; retype convert_to;
@@ -178,7 +178,7 @@ let by_aac_normalise zero lift ir t t' =
       (* This convert is required to deal with evars in a proper
 	 way *)
       let convert_to = mkApp (rlt.Coq.Relation.r, [| mkApp (eval,[| t |]); mkApp (eval, [|t'|])|])   in
-      let convert = Proofview.V82.of_tactic (Tactics.convert_concl convert_to Term.VMcast) in
+      let convert = Proofview.V82.of_tactic (Tactics.convert_concl convert_to Constr.VMcast) in
       let apply_tac = Proofview.V82.of_tactic (Tactics.apply normalise_thm) in
       (Tacticals.tclTHENLIST
 	 [ retype normalise_thm; retype convert_to;
@@ -341,7 +341,7 @@ let choose_subst  subterm sol m=
 	
 (** rewrite the constr modulo AC from left to right in the left member
     of the goal *)
-let aac_rewrite  ?abort rew ?(l2r=true) ?(show = false) ?(in_left=true) ?strict ~occ_subterm ~occ_sol ?extra : Proof_type.tactic  = fun goal ->
+let aac_rewrite_wrap  ?abort rew ?(l2r=true) ?(show = false) ?(in_left=true) ?strict ~occ_subterm ~occ_sol ?extra : Proof_type.tactic  = fun goal ->
   let envs = Theory.Trans.empty_envs () in
   let (concl : types) = Tacmach.pf_concl goal in
   let (_,_,rlt) as concl =
@@ -403,10 +403,10 @@ let aac_rewrite  ?abort rew ?(l2r=true) ?(show = false) ?(in_left=true) ?strict 
 
 let get k l = try Some (List.assoc k l) with Not_found -> None
 
-let get_lhs l = try List.assoc "in_right" l; false with Not_found -> true
+let get_lhs l = try ignore (List.assoc "in_right" l); false with Not_found -> true
   
 let aac_rewrite ~args =
-  aac_rewrite ~occ_subterm:(get "at" args) ~occ_sol:(get "subst" args) ~in_left:(get_lhs args)
+  aac_rewrite_wrap ~occ_subterm:(get "at" args) ~occ_sol:(get "subst" args) ~in_left:(get_lhs args)
 
 
 

--- a/src/coq.ml
+++ b/src/coq.ml
@@ -394,7 +394,7 @@ let get_hypinfo c ~l2r ?check_type  (k : hypinfo -> Proof_type.tactic) :    Proo
   let (rel_context, body_type) = decompose_prod_assum evar_map ctype in
   let rec check f e =
     match decomp_term evar_map e with
-      | Term.Rel i -> f (get_type (Context.Rel.lookup i rel_context))
+      | Constr.Rel i -> f (get_type (Context.Rel.lookup i rel_context))
       | _ -> fold evar_map (fun acc x -> acc && check f x) true e
   in
   begin match check_type with


### PR DESCRIPTION
I ha dto use "EConstr.to_constr ~abort_on_undefined_evars:(false)" to restore old behaviour allowing evars in terms to rewrite.