### PR TITLE
Introduce CI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: nix
+
+script:
+- nix-build --arg coq-version "\"$COQ_VERSION\"" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+
+env:
+  - COQ_VERSION=master
+  - COQ_VERSION=v8.9

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,23 @@
+{ pkgs ? (import <nixpkgs> {}), coq-version ? "master" }:
+
+let
+ coq =
+   let coq-version-parts = builtins.match "([0-9]+).([0-9]+)" coq-version; in
+   if coq-version-parts == null then
+     import (fetchTarball "https://github.com/coq/coq/tarball/${coq-version}") {}
+   else
+     pkgs."coq_${builtins.concatStringsSep "_" coq-version-parts}";
+in
+
+pkgs.stdenv.mkDerivation {
+
+  name = "aac_tactics";
+
+  buildInputs = with coq.ocamlPackages;
+    [ coq ocaml findlib camlp5_strict ]
+    ++ pkgs.lib.optionals pkgs.lib.inNixShell [ merlin ocp-indent ocp-index ];
+
+  src = if pkgs.lib.inNixShell then null else ./.;
+
+  installFlags = "COQLIB=$(out)/lib/coq/";
+}

--- a/src/aac_rewrite.ml
+++ b/src/aac_rewrite.ml
@@ -223,7 +223,7 @@ let aac_normalise = fun goal ->
   let ids = Tacmach.pf_ids_of_hyps goal in
   let mp = MPfile (DirPath.make (List.map Id.of_string ["AAC"; "AAC_tactics"])) in
   let norm_tac = KerName.make2 mp (Label.make "internal_normalize") in
-  let norm_tac = Misctypes.ArgArg (None, norm_tac) in
+  let norm_tac = Locus.ArgArg (None, norm_tac) in
   Tacticals.tclTHENLIST
     [
       aac_conclude by_aac_normalise;

--- a/src/coq.ml
+++ b/src/coq.ml
@@ -8,7 +8,7 @@
 
 (** Interface with Coq *)
 
-open Term
+open Constr
 open EConstr
 open Names
 open Context.Rel.Declaration
@@ -19,7 +19,7 @@ let contrib_name = "aac_tactics"
 (* Getting constrs (primitive Coq terms) from existing Coq
    libraries. *)
 let find_constant contrib dir s =
-  Universes.constr_of_global (Coqlib.find_reference contrib dir s)
+  UnivGen.constr_of_global (Coqlib.find_reference contrib dir s)
 
 let init_constant_constr dir s = find_constant contrib_name dir s
 
@@ -394,7 +394,7 @@ let get_hypinfo c ~l2r ?check_type  (k : hypinfo -> Proof_type.tactic) :    Proo
   let (rel_context, body_type) = decompose_prod_assum evar_map ctype in
   let rec check f e =
     match decomp_term evar_map e with
-      | Constr.Rel i -> f (get_type (Context.Rel.lookup i rel_context))
+      | Rel i -> f (get_type (Context.Rel.lookup i rel_context))
       | _ -> fold evar_map (fun acc x -> acc && check f x) true e
   in
   begin match check_type with
@@ -580,7 +580,7 @@ let rewrite ?(abort=false)hypinfo subst k =
 	    Locus.AllOccurrences
 	    true (* tell if existing evars must be frozen for instantiation *)
 	    false
-	    (rew,Misctypes.NoBindings)
+	    (rew,Tactypes.NoBindings)
 	    true
           end
 	else


### PR DESCRIPTION
This is on top of #10.

This PR adds CI testing on Travis.
Like what was done for other coq-community projects lemma-overloading, qarith-stern-brocot and bertrand, the setup uses Nix to reuse cached binaries for Coq branches.