### PR TITLE
Now uses Proofview and removed CPS at various points

### DIFF
--- a/src/aac.mlg
+++ b/src/aac.mlg
@@ -47,39 +47,39 @@ PRINTED BY { pr_constro }
 END
 
 TACTIC EXTEND _aac_reflexivity_
-| [ "aac_reflexivity" ] -> { Proofview.V82.tactic aac_reflexivity }
+| [ "aac_reflexivity" ] -> { aac_reflexivity }
 END
 
 TACTIC EXTEND _aac_normalise_
-| [ "aac_normalise" ] -> { Proofview.V82.tactic aac_normalise }
+| [ "aac_normalise" ] -> { aac_normalise }
 END
 
 TACTIC EXTEND _aac_rewrite_
 | [ "aac_rewrite" orient(l2r) constr(c) aac_args(args) constro(extra)] ->
-  { Proofview.V82.tactic (fun gl -> aac_rewrite ?extra ~args ~l2r ~strict:true c gl) }
+  { aac_rewrite ?extra ~args ~l2r ~strict:true c }
 END
  
 TACTIC EXTEND _aac_pattern_
 | [ "aac_pattern" orient(l2r) constr(c) aac_args(args) constro(extra)] ->
-  { Proofview.V82.tactic (fun gl -> aac_rewrite ?extra ~args ~l2r ~strict:true ~abort:true c gl) }
+  { aac_rewrite ?extra ~args ~l2r ~strict:true ~abort:true c  }
 END
 
 TACTIC EXTEND _aac_instances_
 | [ "aac_instances" orient(l2r) constr(c) aac_args(args) constro(extra)] ->
-  { Proofview.V82.tactic (fun gl -> aac_rewrite ?extra ~args ~l2r ~strict:true ~show:true c gl) }
+  { aac_rewrite ?extra ~args ~l2r ~strict:true ~show:true c }
 END
 
 TACTIC EXTEND _aacu_rewrite_
 | [ "aacu_rewrite" orient(l2r) constr(c) aac_args(args) constro(extra)] ->
-  { Proofview.V82.tactic (fun gl -> aac_rewrite ?extra ~args ~l2r ~strict:false c gl) }
+  { aac_rewrite ?extra ~args ~l2r ~strict:false c }
 END
  
 TACTIC EXTEND _aacu_pattern_
 | [ "aacu_pattern" orient(l2r) constr(c) aac_args(args) constro(extra)] ->
-  { Proofview.V82.tactic (fun gl -> aac_rewrite ?extra ~args ~l2r ~strict:false ~abort:true c gl) }
+  { aac_rewrite ?extra ~args ~l2r ~strict:false ~abort:true c }
 END
 
 TACTIC EXTEND _aacu_instances_
 | [ "aacu_instances" orient(l2r) constr(c) aac_args(args) constro(extra)] ->
-  { Proofview.V82.tactic (fun gl -> aac_rewrite ?extra ~args ~l2r ~strict:false ~show:true c gl) }
+  { aac_rewrite ?extra ~args ~l2r ~strict:false ~show:true c }
 END

--- a/src/aac_rewrite.ml
+++ b/src/aac_rewrite.ml
@@ -20,17 +20,20 @@ module Debug = Helper.Debug (Control)
 open Debug
 
 let time_tac msg tac =
-  if Control.time then  Coq.tclTIME msg tac else tac
+  if Control.time then  Proofview.tclTIME (Some msg) tac else tac
+  
+let tclTac_or_exn (tac : 'a Proofview.tactic) exn msg : 'a Proofview.tactic =
+  Proofview.tclORELSE tac
+    (fun e ->
+      let open Proofview.Notations in
+      let open Proofview in
+      tclEVARMAP >>= fun sigma ->
+      Goal.enter_one (fun gl ->
+          let env = Proofview.Goal.env gl in
+          pr_constr env sigma "last goal" (Goal.concl gl);
+          exn msg e)
+    )
 
-let tac_or_exn tac exn msg = fun gl ->
-  try tac gl with e ->
-    let env = Tacmach.pf_env gl in
-    let sigma = Tacmach.project gl in
-    pr_constr env sigma "last goal" (Tacmach.pf_concl gl);
-    exn msg e
-
-
-let retype = Coq.retype
 
 open EConstr
 open Names
@@ -61,257 +64,245 @@ type rewinfo =
       lifting: aac_lift
     }
 
-let infer_lifting (rlt: Coq.Relation.t) (k : lift:aac_lift -> Proofview.V82.tac) : Proofview.V82.tac =
-  Coq.cps_evar_relation rlt.Coq.Relation.carrier (fun e ->
-    let lift_ty =
-      mkApp (Lazy.force Theory.Stubs.lift,
-	     [|
-	       rlt.Coq.Relation.carrier;
-	       rlt.Coq.Relation.r;
-	       e
-	     |]
-      ) in
-    Coq.cps_resolve_one_typeclass ~error:(Pp.strbrk "Cannot infer a lifting")
-      lift_ty (fun lift goal ->
-      let x = rlt.Coq.Relation.carrier in
-      let r = rlt.Coq.Relation.r in
-      let eq =  (Coq.nf_evar goal e) in
-      let equiv = Coq.lapp Theory.Stubs.lift_proj_equivalence [| x;r;eq; lift |] in
-      let lift =
-	{
-	  r = rlt;
-	  e = Coq.Equivalence.make x eq equiv;
-	  lift = lift;
-	}
-      in
-      k ~lift:lift  goal
-    ))
+let infer_lifting env sigma (rlt: Coq.Relation.t) : Evd.evar_map * aac_lift  =
+  let x = rlt.Coq.Relation.carrier in
+  let r = rlt.Coq.Relation.r in
+  let (sigma, e) = Coq.evar_relation env sigma x in
+  let lift_ty = mkApp (Lazy.force Theory.Stubs.lift,[|x;r;e|]) in
+  let sigma, lift = try Typeclasses.resolve_one_typeclass env sigma lift_ty
+                    with Not_found -> CErrors.user_err (Pp.strbrk "Cannot infer a lifting")
+  in
+  let eq = (Evarutil.nf_evar sigma e) in
+  let equiv = mkApp (Lazy.force Theory.Stubs.lift_proj_equivalence,[| x;r;eq; lift |]) in
+  sigma, {
+      r = rlt;
+      e = Coq.Equivalence.make x eq equiv;
+      lift = lift;
+    }
+  
 
 (** Builds a rewinfo, once and for all *)
-let dispatch in_left (left,right,rlt) hypinfo (k: rewinfo -> Proofview.V82.tac ) : Proofview.V82.tac=
+let dispatch env sigma in_left (left,right,rlt) hypinfo : Evd.evar_map * rewinfo =
   let l2r = hypinfo.Coq.Rewrite.l2r in
-  infer_lifting rlt
-    (fun ~lift ->
-      let eq = lift.e in
-      k {
-	hypinfo = hypinfo;
-	in_left = in_left;
-	pattern = if l2r then hypinfo.Coq.Rewrite.left else hypinfo.Coq.Rewrite.right;
-	subject = if in_left then  left else right;
-	morph_rlt = Coq.Equivalence.to_relation eq;
-	eqt = eq;
-	lifting = lift;
-	rlt = rlt
-      }
-    )
-
+  let sigma,lift = infer_lifting env sigma rlt in
+  let eq = lift.e in
+  sigma,{
+      hypinfo = hypinfo;
+      in_left = in_left;
+      pattern = if l2r then hypinfo.Coq.Rewrite.left else hypinfo.Coq.Rewrite.right;
+      subject = if in_left then left else right;
+      morph_rlt = Coq.Equivalence.to_relation eq;
+      eqt = eq;
+      lifting = lift;
+      rlt = rlt
+    }
 
 
 (** {1 Tactics} *)
 
 
 (** Build the reifiers, the reified terms, and the evaluation fonction  *)
-let handle eqt zero envs (t : Matcher.Terms.t) (t' : Matcher.Terms.t) k =
-
+let handle eqt zero envs (t : Matcher.Terms.t) (t' : Matcher.Terms.t) : ('a * 'b * 'c * 'd) Proofview.tactic=
   let (x,r,_) = Coq.Equivalence.split eqt  in
-  Theory.Trans.mk_reifier (Coq.Equivalence.to_relation eqt) zero envs
-    (fun (maps, reifier) ->
-      (* fold through a term and reify *)
-      let t = Theory.Trans.reif_constr_of_t reifier t in
-      let t' = Theory.Trans.reif_constr_of_t reifier  t' in
-      (* Some letins  *)
-      let eval = (mkApp (Lazy.force Theory.Stubs.eval, [|x;r; maps.Theory.Trans.env_sym; maps.Theory.Trans.env_bin; maps.Theory.Trans.env_units|])) in
+  let open Proofview.Notations in
+  Theory.Trans.mk_reifier (Coq.Equivalence.to_relation eqt) zero envs >>= fun (maps, reifier) ->
+  (* fold through a term and reify *)
+  let t = Theory.Trans.reif_constr_of_t reifier t in
+  let t' = Theory.Trans.reif_constr_of_t reifier  t' in
+  (* Some letins  *)
+  let eval = (mkApp (Lazy.force Theory.Stubs.eval, [|x;r; maps.Theory.Trans.env_sym; maps.Theory.Trans.env_bin; maps.Theory.Trans.env_units|])) in
 
-      Coq.cps_mk_letin "eval" eval (fun eval ->
-	Coq.cps_mk_letin "left" t (fun t ->
-	  Coq.cps_mk_letin "right" t' (fun t' ->
-	    k maps eval t t'))))
-
+  Coq.mk_letin "eval" eval >>= fun eval ->
+  Coq.mk_letin "left" t >>= fun t ->
+  Coq.mk_letin "right" t' >>= fun t' ->
+  Proofview.tclUNIT (maps, eval, t,t')
+                                   
 (** [by_aac_reflexivity] is a sub-tactic that closes a sub-goal that
       is merely a proof of equality of two terms modulo AAC *)
 let by_aac_reflexivity zero
-    eqt envs (t : Matcher.Terms.t) (t' : Matcher.Terms.t) : Proofview.V82.tac =
-  handle eqt zero envs t t'
-    (fun maps eval t t' ->
-      let (x,r,e) = Coq.Equivalence.split eqt in
-      let decision_thm = Coq.lapp Theory.Stubs.decide_thm
-	[|x;r;e;
-	  maps.Theory.Trans.env_sym;
-	  maps.Theory.Trans.env_bin;
-	  maps.Theory.Trans.env_units;
-	  t;t';
-	|]
-      in
-      (* This convert is required to deal with evars in a proper
-	 way *)
-      let convert_to = mkApp (r, [| mkApp (eval,[| t |]); mkApp (eval, [|t'|])|])   in
-      let convert = Proofview.V82.of_tactic (Tactics.convert_concl convert_to Constr.VMcast) in
-      let apply_tac = Proofview.V82.of_tactic (Tactics.apply decision_thm) in
-      (Tacticals.tclTHENLIST
-	 [ retype decision_thm; retype convert_to;
-	   convert ;
-	   tac_or_exn apply_tac Coq.user_error (Pp.strbrk "unification failure");
-	   tac_or_exn (time_tac "vm_norm" (Proofview.V82.of_tactic (Tactics.normalise_in_concl))) Coq.anomaly "vm_compute failure";
-	   Tacticals.tclORELSE (Proofview.V82.of_tactic Tactics.reflexivity)
-	     (Tacticals.tclFAIL 0 (Pp.str "Not an equality modulo A/AC"))
-	 ])
-    )
+      eqt envs (t : Matcher.Terms.t) (t' : Matcher.Terms.t) : unit Proofview.tactic =
+  let open Proofview.Notations in
+  handle eqt zero envs t t' >>= fun (maps,eval,t,t') ->
+  let (x,r,e) = Coq.Equivalence.split eqt in
+  let decision_thm = Coq.lapp Theory.Stubs.decide_thm
+	               [|x;r;e;
+	                 maps.Theory.Trans.env_sym;
+	                 maps.Theory.Trans.env_bin;
+	                 maps.Theory.Trans.env_units;
+	                 t;t';
+	               |]
+  in
+  (* This convert is required to deal with evars in a proper
+     way *)
+  let convert_to = mkApp (r, [| mkApp (eval,[| t |]); mkApp (eval, [|t'|])|])   in
+  let convert = Tactics.convert_concl convert_to Constr.VMcast in
+  let apply_tac = Tactics.apply decision_thm in
+  let open Proofview in
+  Coq.tclRETYPE decision_thm
+  <*> Coq.tclRETYPE convert_to
+  <*> convert
+  <*> tclTac_or_exn apply_tac Coq.user_error (Pp.strbrk "unification failure")
+  <*> tclTac_or_exn (time_tac "vm_norm" Tactics.normalise_in_concl) Coq.anomaly "vm_compute failure"
+  <*> tclORELSE Tactics.reflexivity
+	(fun _ -> Tacticals.New.tclFAIL 0 (Pp.str "Not an equality modulo A/AC"))
+  
+
 
 let by_aac_normalise zero lift ir t t' =
   let eqt = lift.e in
   let rlt = lift.r in
-  handle eqt zero ir t t'
-    (fun  maps eval t t' ->
-      let (x,r,e) = Coq.Equivalence.split eqt in
-      let normalise_thm = Coq.lapp Theory.Stubs.lift_normalise_thm
-	[|x;r;e;
-	  maps.Theory.Trans.env_sym;
-	  maps.Theory.Trans.env_bin;
-	  maps.Theory.Trans.env_units;
-	  rlt.Coq.Relation.r;
-	  lift.lift;
-	  t;t';
-	|]
-      in
-      (* This convert is required to deal with evars in a proper
-	 way *)
-      let convert_to = mkApp (rlt.Coq.Relation.r, [| mkApp (eval,[| t |]); mkApp (eval, [|t'|])|])   in
-      let convert = Proofview.V82.of_tactic (Tactics.convert_concl convert_to Constr.VMcast) in
-      let apply_tac = Proofview.V82.of_tactic (Tactics.apply normalise_thm) in
-      (Tacticals.tclTHENLIST
-	 [ retype normalise_thm; retype convert_to;
-	   convert ;
-	   apply_tac;
-	 ])
+  let open Proofview.Notations in
+  handle eqt zero ir t t' >>= fun (maps,eval,t,t') ->
+  let (x,r,e) = Coq.Equivalence.split eqt in
+  let normalise_thm = Coq.lapp Theory.Stubs.lift_normalise_thm
+	                [|x;r;e;
+	                  maps.Theory.Trans.env_sym;
+	                  maps.Theory.Trans.env_bin;
+	                  maps.Theory.Trans.env_units;
+	                  rlt.Coq.Relation.r;
+	                  lift.lift;
+	                  t;t';
+	                |]
+  in
+  (* This convert is required to deal with evars in a proper
+     way *)
+  let convert_to = mkApp (rlt.Coq.Relation.r, [| mkApp (eval,[| t |]); mkApp (eval, [|t'|])|])   in
+  let convert = Tactics.convert_concl convert_to Constr.VMcast in
+  let apply_tac = Tactics.apply normalise_thm in
+  Tacticals.New.tclTHENLIST
+    [ Coq.tclRETYPE normalise_thm; Coq.tclRETYPE convert_to;
+       convert ;
+       apply_tac;
+     ]
+  
 
-    )
 
-(** A handler tactic, that reifies the goal, and infer the liftings,
-    and then call its continuation *)
-let aac_conclude
-    (k : constr -> aac_lift -> Theory.Trans.ir -> Matcher.Terms.t -> Matcher.Terms.t -> Proofview.V82.tac) = fun goal ->
-
-    let (equation : types) = Tacmach.pf_concl goal in
-    let envs = Theory.Trans.empty_envs () in
-    let left, right,r =
-      match Coq.match_as_equation goal equation with
-	| None -> Coq.user_error @@ Pp.strbrk "The goal is not an applied relation"
-	| Some x -> x in
-    try infer_lifting r
-      (fun ~lift  goal ->
-	let eq = Coq.Equivalence.to_relation lift.e in
-	let tleft,tright, goal = Theory.Trans.t_of_constr goal eq envs (left,right)   in
-	let goal, ir = Theory.Trans.ir_of_envs goal eq envs in
-	let concl = Tacmach.pf_concl goal in
-        let env = Tacmach.pf_env goal in
-        let sigma = Tacmach.project goal in
-        let _ = pr_constr env sigma "concl "concl in
-	let evar_map = Tacmach.project goal in
-	Tacticals.tclTHEN
-	  (Refiner.tclEVARS evar_map)
-	  (k left lift ir tleft tright)
-	  goal
-      )goal
+(** A handler function, that reifies the goal, and infers the lifting *)
+let aac_conclude env sigma (concl:types): ( Evd.evar_map * constr * aac_lift * Theory.Trans.ir * Matcher.Terms.t * Matcher.Terms.t) =
+  let envs = Theory.Trans.empty_envs () in
+  let left, right,r =
+    match Coq.match_as_equation env sigma concl with
+    | None -> Coq.user_error @@ Pp.strbrk "The goal is not an applied relation"
+    | Some x -> x in
+  try let sigma,lift = infer_lifting env sigma r in
+      let eq = Coq.Equivalence.to_relation lift.e in
+      let tleft,tright, sigma = Theory.Trans.t_of_constr env sigma eq envs (left,right) in
+      let sigma, ir = Theory.Trans.ir_of_envs env sigma eq envs in
+      let _ = pr_constr env sigma "concl" concl in
+      (sigma,left,lift,ir,tleft,tright)
   with
-    | Not_found -> Coq.user_error @@ Pp.strbrk "No lifting from the goal's relation to an equivalence"
+  | Not_found -> Coq.user_error @@ Pp.strbrk "No lifting from the goal's relation to an equivalence"
 
 open Tacexpr
 
-let aac_normalise = fun goal ->
-  let ids = Tacmach.pf_ids_of_hyps goal in
+let aac_normalise =
   let mp = MPfile (DirPath.make (List.map Id.of_string ["AAC"; "AAC_tactics"])) in
   let norm_tac = KerName.make mp (Label.make "internal_normalize") in
   let norm_tac = Locus.ArgArg (None, norm_tac) in
-  Tacticals.tclTHENLIST
+  let open Proofview.Notations in
+  let open Proofview in
+  Proofview.Goal.enter (fun goal -> 
+      let ids = Tacmach.New.pf_ids_of_hyps goal in
+      let env = Proofview.Goal.env goal in
+      tclEVARMAP >>= fun sigma ->
+      let concl = Proofview.Goal.concl goal in
+      let sigma,left,lift,ir,tleft,tright = aac_conclude env sigma concl in
+      Tacticals.New.tclTHENLIST
     [
-      aac_conclude by_aac_normalise;
-      Proofview.V82.of_tactic (Tacinterp.eval_tactic (TacArg (CAst.(make @@ TacCall (make (norm_tac, []))))));
-      Proofview.V82.of_tactic (Tactics.keep ids)
-    ] goal
+      Unsafe.tclEVARS sigma;
+      by_aac_normalise left lift ir tleft tright;
+      Tacinterp.eval_tactic (TacArg (CAst.(make @@ TacCall (make (norm_tac, [])))));
+      Tactics.keep ids
+    ])
 
-let aac_reflexivity = fun goal ->
-  aac_conclude
-    (fun zero lift ir t t' ->
+let aac_reflexivity : unit Proofview.tactic =
+  let open Proofview.Notations in
+  let open Proofview in
+  tclEVARMAP >>= fun sigma ->
+  Goal.enter (fun goal ->
+      let env = Proofview.Goal.env goal in
+      let concl = Goal.concl goal in
+      let sigma,zero,lift,ir,t,t' = aac_conclude env sigma concl in
       let x,r = Coq.Relation.split (lift.r) in
       let r_reflexive = (Coq.Classes.mk_reflexive x r) in
-      Coq.cps_resolve_one_typeclass ~error:(Pp.strbrk "The goal's relation is not reflexive")
-	r_reflexive
-	(fun reflexive ->
-	  let lift_reflexivity =
-	    mkApp (Lazy.force (Theory.Stubs.lift_reflexivity),
-		   [|
-		     x;
-		     r;
-		     lift.e.Coq.Equivalence.eq;
-		     lift.lift;
-		     reflexive
-		   |])
-	  in
-	  Tacticals.tclTHEN
+      let sigma,reflexive = try Typeclasses.resolve_one_typeclass env sigma r_reflexive
+                            with | Not_found -> Coq.user_error @@ Pp.strbrk "The goal's relation is not reflexive"
+      in
+      let lift_reflexivity =
+        mkApp (Lazy.force (Theory.Stubs.lift_reflexivity),
+	       [| x; r; lift.e.Coq.Equivalence.eq; lift.lift; reflexive |])
+      in
+      Unsafe.tclEVARS sigma 
+      <*> Tactics.apply lift_reflexivity
+      <*> (let concl = Goal.concl goal in
+           tclEVARMAP >>= fun sigma ->
+           let _ = pr_constr env sigma "concl "concl in
+           by_aac_reflexivity zero lift.e ir t t')
+    )
 
-	  (Tacticals.tclTHEN (retype lift_reflexivity) (Proofview.V82.of_tactic (Tactics.apply lift_reflexivity)))
-	    (fun goal ->
-	      let concl = Tacmach.pf_concl goal in
-              let env = Tacmach.pf_env goal in
-              let sigma = Tacmach.project goal in
-	      let _ = pr_constr env sigma "concl "concl in
-	      by_aac_reflexivity zero lift.e ir t t' goal)
-	)
-    ) goal
 
 (** A sub-tactic to lift the rewriting using Lift  *)
-let lift_transitivity in_left (step:constr) preorder lifting (using_eq : Coq.Equivalence.t): Proofview.V82.tac =
-  fun goal ->
-    (* catch the equation and the two members*)
-    let concl = Tacmach.pf_concl goal in
-    let (left, right, _ ) = match  Coq.match_as_equation goal concl with
-      | Some x -> x
-      | None -> Coq.user_error @@ Pp.strbrk "The goal is not an equation"
-    in
-    let lift_transitivity =
-      let thm =
-	if in_left
-	then
-	  Lazy.force Theory.Stubs.lift_transitivity_left
-	else
-	  Lazy.force Theory.Stubs.lift_transitivity_right
+let lift_transitivity in_left (step:constr) preorder lifting (using_eq : Coq.Equivalence.t): unit Proofview.tactic =
+  let open Proofview.Notations in
+  let open Proofview in
+  Proofview.Goal.enter (fun goal ->
+      (* catch the equation and the two members*)
+      let concl = Proofview.Goal.concl goal in
+      let env = Proofview.Goal.env goal in
+      tclEVARMAP >>= fun sigma ->
+      let (left, right, _ ) = match  Coq.match_as_equation env sigma concl with
+        | Some x -> x
+        | None -> Coq.user_error @@ Pp.strbrk "The goal is not an equation"
       in
-      mkApp (thm,
-	     [|
-	       preorder.Coq.Relation.carrier;
-	       preorder.Coq.Relation.r;
-	       using_eq.Coq.Equivalence.eq;
-	       lifting;
-	       step;
-	       left;
-	       right;
-	     |])
-    in
-    Tacticals.tclTHENLIST
-      [ retype lift_transitivity;
-	Proofview.V82.of_tactic (Tactics.apply lift_transitivity)
-      ] goal
+      let lift_transitivity =
+        let thm =
+	  if in_left
+	  then
+	    Lazy.force Theory.Stubs.lift_transitivity_left
+	  else
+	    Lazy.force Theory.Stubs.lift_transitivity_right
+        in
+        mkApp (thm,
+	       [|
+	         preorder.Coq.Relation.carrier;
+	         preorder.Coq.Relation.r;
+	         using_eq.Coq.Equivalence.eq;
+	         lifting;
+	         step;
+	         left;
+	         right;
+	       |])
+      in
+      Tacticals.New.tclTHENLIST
+        [ Coq.tclRETYPE lift_transitivity;
+          Tactics.apply lift_transitivity
+        ]
+    )
 
-
-(** The core tactic for aac_rewrite. Env and sigma are for the constr *)
+(** The core tactic for aac_rewrite. *)
 let core_aac_rewrite ?abort
-    rewinfo
-    subst
-    (by_aac_reflexivity : Matcher.Terms.t -> Matcher.Terms.t -> Proofview.V82.tac)
-    env sigma (tr : constr) t left : Proofview.V82.tac =
-  pr_constr env sigma "transitivity through" tr;
-  let tran_tac =
-    lift_transitivity rewinfo.in_left tr rewinfo.rlt rewinfo.lifting.lift rewinfo.eqt
-  in
-  Coq.Rewrite.rewrite ?abort rewinfo.hypinfo subst (fun rew ->
-    Tacticals.tclTHENSV
-      (tac_or_exn (tran_tac) Coq.anomaly "Unable to make the transitivity step")
-      (
-	if rewinfo.in_left
-	then [| by_aac_reflexivity left t ; rew |]
-	else [| by_aac_reflexivity t left ; rew  |]
-      )
-  )
+      rewinfo
+      subst
+      (by_aac_reflexivity : Matcher.Terms.t -> Matcher.Terms.t -> unit Proofview.tactic)
+      (tr : constr) t left : unit Proofview.tactic =
+  let open Proofview.Notations in
+  Proofview.Goal.enter (fun goal ->
+      let env = Proofview.Goal.env goal in
+      Proofview.tclEVARMAP >>= fun sigma ->
+      pr_constr env sigma "transitivity through" tr;
+      let tran_tac =
+        lift_transitivity rewinfo.in_left tr rewinfo.rlt rewinfo.lifting.lift rewinfo.eqt
+      in
+      let rew = Coq.Rewrite.rewrite ?abort rewinfo.hypinfo subst in
+      Tacticals.New.tclTHENS
+        (tclTac_or_exn (tran_tac) Coq.anomaly "Unable to make the transitivity step")
+        (
+	  if rewinfo.in_left
+	  then [ by_aac_reflexivity left t ; rew ]
+	  else [ by_aac_reflexivity t left ; rew ]
+        )
+    )
+  
 
 exception NoSolutions
 
@@ -339,65 +330,64 @@ let choose_subst  subterm sol m=
 
 (** rewrite the constr modulo AC from left to right in the left member
     of the goal *)
-let aac_rewrite_wrap  ?abort rew ?(l2r=true) ?(show = false) ?(in_left=true) ?strict ~occ_subterm ~occ_sol ?extra : Proofview.V82.tac  = fun goal ->
-  let envs = Theory.Trans.empty_envs () in
-  let (concl : types) = Tacmach.pf_concl goal in
-  let (_,_,rlt) as concl =
-    match Coq.match_as_equation goal concl with
-      | None -> Coq.user_error @@ Pp.strbrk "The goal is not an applied relation"
-      | Some (left, right, rlt) -> left,right,rlt
-  in
-  let check_type x =
-    Tacmach.pf_conv_x goal x rlt.Coq.Relation.carrier
-  in
-  Coq.Rewrite.get_hypinfo rew ~l2r ?check_type:(Some check_type)
-    (fun hypinfo ->
-      dispatch in_left concl hypinfo
-	(
-	  fun rewinfo ->
-	    let goal =
-	      match extra with
-		| Some t -> Theory.Trans.add_symbol goal rewinfo.morph_rlt envs (EConstr.to_constr (Tacmach.project goal) t)
-		| None -> goal
-	    in
-	    let pattern, subject, goal =
-	      Theory.Trans.t_of_constr goal rewinfo.morph_rlt envs
-		(rewinfo.pattern , rewinfo.subject)
-	    in
-	    let goal, ir = Theory.Trans.ir_of_envs goal rewinfo.morph_rlt envs in
+let aac_rewrite_wrap  ?abort ?(l2r=true) ?(show = false) ?(in_left=true) ?strict ?extra ~occ_subterm ~occ_sol rew : unit Proofview.tactic =
+  let open Proofview.Notations in
+  let open Proofview in
+  Proofview.Goal.enter (fun goal ->
+      let envs = Theory.Trans.empty_envs () in
+      let (concl : types) = Proofview.Goal.concl goal in
+      let env = Proofview.Goal.env goal in
+      tclEVARMAP >>= fun sigma ->
+      let (_,_,rlt) as concl =
+        match Coq.match_as_equation env sigma concl with
+        | None -> Coq.user_error @@ Pp.strbrk "The goal is not an applied relation"
+        | Some (left, right, rlt) -> left,right,rlt
+      in
+      let check_type x =
+        Tacmach.New.pf_conv_x goal x rlt.Coq.Relation.carrier
+      in
+      let hypinfo = Coq.Rewrite.get_hypinfo env sigma rew ~l2r ?check_type:(Some check_type) in      
+      let sigma,rewinfo = dispatch env sigma in_left concl hypinfo in
+      let sigma =
+        match extra with
+        | Some t -> Theory.Trans.add_symbol env sigma rewinfo.morph_rlt envs (EConstr.to_constr sigma t)
+        | None -> sigma
+      in
+      let pattern, subject, sigma =
+        Theory.Trans.t_of_constr env sigma rewinfo.morph_rlt envs
+          (rewinfo.pattern , rewinfo.subject)
+      in
+      let sigma, ir = Theory.Trans.ir_of_envs env sigma rewinfo.morph_rlt envs in
+      let open Proofview.Notations in
+      Proofview.Unsafe.tclEVARS sigma
+      <*> let units = Theory.Trans.ir_to_units ir in
+          let m =  Matcher.subterm ?strict units pattern subject in
+          (* We sort the monad in increasing size of contet *)
+          let m = Search_monad.sort (fun (x,_,_) (y,_,_) -> x -  y) m in
 
-	    let units = Theory.Trans.ir_to_units ir in
-	    let m =  Matcher.subterm ?strict units pattern subject in
-	    (* We sort the monad in increasing size of contet *)
-	    let m = Search_monad.sort (fun (x,_,_) (y,_,_) -> x -  y) m in
+          (if show
+           then
+             Print.print rewinfo.morph_rlt ir m (hypinfo.Coq.Rewrite.context)
+           else
+             try
+               let pat,subst = choose_subst occ_subterm occ_sol m in
+               let tr_step = Matcher.Subst.instantiate subst pat in
+               let tr_step_raw = Theory.Trans.raw_constr_of_t ir rewinfo.morph_rlt [] tr_step in
 
-	    if show
-	    then
-	      Print.print rewinfo.morph_rlt ir m (hypinfo.Coq.Rewrite.context)
-
-	    else
-	      try
-		let pat,subst = choose_subst occ_subterm occ_sol m in
-		let tr_step = Matcher.Subst.instantiate subst pat in
-		let tr_step_raw = Theory.Trans.raw_constr_of_t ir rewinfo.morph_rlt [] tr_step in
-
-		let conv = (Theory.Trans.raw_constr_of_t ir rewinfo.morph_rlt (hypinfo.Coq.Rewrite.context)) in
-		let subst  = Matcher.Subst.to_list subst in
-		let subst = List.map (fun (x,y) -> x, conv y) subst in
-		let by_aac_reflexivity = (by_aac_reflexivity rewinfo.subject rewinfo.eqt  ir) in
-                let env = Tacmach.pf_env goal in
-                let sigma = Tacmach.project goal in
-                (* I'm not sure whether this is the right env/sigma for printing tr_step_raw *)
-		core_aac_rewrite ?abort rewinfo subst by_aac_reflexivity env sigma tr_step_raw tr_step subject
-
-	      with
-		| NoSolutions ->
-		  Tacticals.tclFAIL 0
-		    (Pp.str (if occ_subterm = None && occ_sol = None
-		      then "No matching occurrence modulo AC found"
-		      else "No such solution"))
-	)
-    ) goal
+               let conv = (Theory.Trans.raw_constr_of_t ir rewinfo.morph_rlt (hypinfo.Coq.Rewrite.context)) in
+               let subst  = Matcher.Subst.to_list subst in
+               let subst = List.map (fun (x,y) -> x, conv y) subst in
+               let by_aac_reflexivity = (by_aac_reflexivity rewinfo.subject rewinfo.eqt  ir) in
+               (* I'm not sure whether this is the right env/sigma for printing tr_step_raw *)
+               core_aac_rewrite ?abort rewinfo subst by_aac_reflexivity tr_step_raw tr_step subject
+             with
+             | NoSolutions ->
+                Tacticals.New.tclFAIL 0
+	          (Pp.str (if occ_subterm = None && occ_sol = None
+		           then "No matching occurrence modulo AC found"
+		           else "No such solution"))
+          ))
+  
 
 let get k l = try Some (List.assoc k l) with Not_found -> None
 

--- a/src/aac_rewrite.mli
+++ b/src/aac_rewrite.mli
@@ -8,16 +8,15 @@
 
 (** aac_rewrite -- rewriting modulo A or AC*)
 
-val aac_reflexivity : Coq.goal_sigma -> Goal.goal list Evd.sigma
-val aac_normalise : Coq.goal_sigma -> Goal.goal list Evd.sigma
+val aac_reflexivity : unit Proofview.tactic
+val aac_normalise : unit Proofview.tactic
 
 val aac_rewrite :
   args:(string * int) list ->
   ?abort:bool ->
-  EConstr.constr ->
   ?l2r:bool ->
   ?show:bool ->
-  ?strict:bool -> ?extra:EConstr.t -> Proofview.V82.tac
+  ?strict:bool -> ?extra:EConstr.t -> EConstr.constr -> unit Proofview.tactic
 
 val add : string -> 'a -> (string * 'a) list -> (string * 'a) list
 

--- a/src/print.ml
+++ b/src/print.ml
@@ -68,11 +68,11 @@ let pp_all pt : (int * Terms.t * named_env Search_monad.m) Search_monad.m -> Pp.
 rename the variables, and rebuilds raw Coq terms (for the context, and
 the terms in the environment). In order to do so, it requires the
 information gathered by the {!Theory.Trans} module.*)
-let print rlt ir m (context : EConstr.rel_context) goal =
+let print rlt ir m (context : EConstr.rel_context) : unit Proofview.tactic =
   if Search_monad.count m = 0
   then
     (
-      Tacticals.tclFAIL 0  (Pp.str "No subterm modulo AC")  goal
+      Tacticals.New.tclFAIL 0  (Pp.str "No subterm modulo AC")
     )
   else
     let _ = Feedback.msg_notice (Pp.str "All solutions:") in
@@ -93,12 +93,13 @@ let print rlt ir m (context : EConstr.rel_context) goal =
       )
     in
     let m = Search_monad.sort (fun (x,_,_) (y,_,_) -> x -  y) m in
-    let env = Tacmach.pf_env goal in
-    let sigma = Tacmach.project goal in
+    let open Proofview.Notations in
+    Proofview.tclENV >>= fun env ->
+    Proofview.tclEVARMAP >>= fun sigma ->
     let _ = Feedback.msg_notice
       (pp_all
 	 (fun t -> Printer.pr_letype_env env sigma (Theory.Trans.raw_constr_of_t ir rlt  context  t)) m
       )
     in
-    Tacticals.tclIDTAC goal
+    Tacticals.New.tclIDTAC
      

--- a/src/print.mli
+++ b/src/print.mli
@@ -19,5 +19,5 @@ val print :
   Theory.Trans.ir ->
   (int * Matcher.Terms.t * Matcher.Subst.t Search_monad.m) Search_monad.m ->
   EConstr.rel_context  ->
-  Proofview.V82.tac
+  unit Proofview.tactic
 

--- a/src/theory.mli
+++ b/src/theory.mli
@@ -137,11 +137,11 @@ module Trans :  sig
       evars; this is why we give back the [goal], accordingly
       updated. *)
   
-  val t_of_constr : Coq.goal_sigma -> Coq.Relation.t -> envs -> (EConstr.constr * EConstr.constr) -> Matcher.Terms.t * Matcher.Terms.t * Coq.goal_sigma
+  val t_of_constr : Environ.env -> Evd.evar_map -> Coq.Relation.t -> envs -> (EConstr.constr * EConstr.constr) -> Matcher.Terms.t * Matcher.Terms.t * Evd.evar_map
 
   (** [add_symbol] adds a given binary symbol to the environment of
       known stuff. *)
-  val add_symbol : Coq.goal_sigma -> Coq.Relation.t -> envs -> Constr.t -> Coq.goal_sigma
+  val add_symbol : Environ.env -> Evd.evar_map -> Coq.Relation.t -> envs -> Constr.t -> Evd.evar_map
 
   (** {2 Reconstruction: from AST back to Coq terms  }
      
@@ -152,7 +152,7 @@ module Trans :  sig
       the reflexive decision procedure. *)
 
   type ir
-  val ir_of_envs : Coq.goal_sigma -> Coq.Relation.t -> envs -> Coq.goal_sigma * ir
+  val ir_of_envs : Environ.env -> Evd.evar_map -> Coq.Relation.t -> envs -> Evd.evar_map * ir
   val ir_to_units : ir -> Matcher.ext_units
 
   (** {2 Building raw, natural, terms} *)
@@ -189,7 +189,7 @@ module Trans :  sig
       reify each term successively.*)
   type reifier
 
-  val mk_reifier :   Coq.Relation.t -> EConstr.constr -> ir -> (sigmas * reifier -> Proofview.V82.tac) -> Proofview.V82.tac
+  val mk_reifier : Coq.Relation.t -> EConstr.constr -> ir -> (sigmas * reifier) Proofview.tactic
 
   (** [reif_constr_of_t  reifier t] rebuilds the term [t] in the
       reified form. *)


### PR DESCRIPTION
Don't merge yet!

I reworked some of the code to use the Proofview-monad, remove CPS and pass arround sigmas and envs instead of `goal`. This is a step towards me adding new features to aac_rewrite.

But I'm not sure if I didn't break anything on the way.

@palmskog: Could you test this with your project? I can also backport my changes to another coq-version if this is necessary for that.

Also, I want this to be tested on other developments, but I don't have time for this this week.