### PR TITLE
[coq] Adapt to coq/coq#9129 "removal of imperative proof state"

### DIFF
--- a/src/coq.ml
+++ b/src/coq.ml
@@ -74,16 +74,14 @@ let tclPRINT =
       let _ = Feedback.msg_notice (Printer.pr_goal (Proofview.Goal.print goal)) in                  
       tclUNIT ())
 
-let tclSHOWPROOF : unit Proofview.tactic=
-  let open Proofview.Notations in
-  let open Proofview in
-  tclEVARMAP >>= fun sigma ->
-  tclENV >>= fun env ->
-  let p = Proof_global.give_me_the_proof () in 
+let show_proof pstate : unit =
+  let sigma, env = Pfedit.get_current_context pstate in
+  let p = Proof_global.give_me_the_proof pstate in 
   let p = Proof.partial_proof p in 
   let p = List.map (Evarutil.nf_evar sigma) p in 
-  let _ = List.map (fun c -> Feedback.msg_notice (Printer.pr_econstr_env env sigma c)) p (* list of econstr in sigma *) in
-  Tacticals.New.tclIDTAC
+  let () = List.iter (fun c -> Feedback.msg_notice (Printer.pr_econstr_env env sigma c)) p (* list of econstr in sigma *) in
+  ()
+
 
 let cps_mk_letin
     (name:string)

--- a/src/coq.mli
+++ b/src/coq.mli
@@ -162,15 +162,16 @@ val tclDEBUG : string -> unit Proofview.tactic
 (** print the current goal *)
 val tclPRINT : unit Proofview.tactic
 
-(** print the current proof term *)
-val tclSHOWPROOF : unit Proofview.tactic
-
 (** {2 Error related mechanisms}  *)
 
 val anomaly : string -> 'a
 val user_error : Pp.t -> 'a
 val warning : string -> unit
 
+(** {2 Helpers}  *)
+
+(** print the current proof term *)
+val show_proof : Proof_global.t -> unit
 
 (** {2 Rewriting tactics used in aac_rewrite}  *)
 


### PR DESCRIPTION
Note, I think that show proof cannot be implemented as a tactic as of
today; however the API could be extended to expose the proof if so we
wanted.

cc: @ppedrot 

p.s: This should be merged already, sorry for the oversight on submitting the PR.