### PR TITLE
Adjusted way the Coq-constants are bind in ocaml

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -22,6 +22,7 @@ src/aac.mlg
 src/aac_plugin.mlpack
 
 theories/Utils.v
+theories/Constants.v
 theories/AAC.v
 theories/Instances.v
 theories/Tutorial.v

--- a/src/coq.mli
+++ b/src/coq.mli
@@ -22,9 +22,13 @@
 *)
 
 (** {2 Getting Coq terms from the environment}  *)
+type lazy_ref = Names.GlobRef.t Lazy.t
 
-val init_constant_constr : string list -> string -> Constr.t
-val init_constant : string list -> string -> EConstr.constr
+val get_fresh : lazy_ref -> Constr.constr
+val get_efresh : lazy_ref -> EConstr.constr
+  
+val find_global : string -> lazy_ref
+
 
 (** {2 General purpose functions} *)
 
@@ -43,7 +47,6 @@ val retype : EConstr.constr -> Proofview.V82.tac
 val tclRETYPE : EConstr.constr -> unit Proofview.tactic
 
 val decomp_term : Evd.evar_map -> EConstr.constr -> (EConstr.constr , EConstr.types, EConstr.ESorts.t, EConstr.EInstance.t) Constr.kind_of_term
-val lapp : EConstr.constr lazy_t -> EConstr.constr array -> EConstr.constr
 
 (** {2 Bindings with Coq' Standard Library}  *)
 
@@ -60,30 +63,14 @@ end
 (** Coq pairs *)
 module Pair:
 sig
-  val typ:EConstr.constr lazy_t
-  val pair:EConstr.constr lazy_t
+  val typ: lazy_ref
+  val pair: lazy_ref
   val of_pair : EConstr.constr -> EConstr.constr ->  EConstr.constr * EConstr.constr -> EConstr.constr
 end
 
-module Bool : sig
-  val typ : EConstr.constr lazy_t
-  val of_bool : bool -> EConstr.constr
-end
-
-
-module Comparison : sig
-  val typ : EConstr.constr lazy_t
-  val eq : EConstr.constr lazy_t
-  val lt : EConstr.constr lazy_t
-  val gt : EConstr.constr lazy_t
-end
-
-module Leibniz : sig
-  val eq_refl : EConstr.types -> EConstr.constr -> EConstr.constr
-end
 
 module Option : sig
-  val typ : EConstr.constr lazy_t
+  val typ : lazy_ref
   val some : EConstr.constr -> EConstr.constr -> EConstr.constr
   val none : EConstr.constr -> EConstr.constr
   val of_option : EConstr.constr -> EConstr.constr option -> EConstr.constr
@@ -92,15 +79,15 @@ end
 (** Coq positive numbers (pos) *)
 module Pos:
 sig
-  val typ:EConstr.constr lazy_t
+  val typ:lazy_ref
   val of_int: int ->EConstr.constr
 end
 
 (** Coq unary numbers (peano) *)
 module Nat:
 sig
-  val typ:EConstr.constr lazy_t
-  val of_int: int ->EConstr.constr
+  val typ:lazy_ref
+  val of_int: int -> Constr.constr
 end
 
 (** Coq typeclasses *)
@@ -118,19 +105,6 @@ module Relation : sig
   val split : t -> EConstr.constr * EConstr.constr
 end
    
-module Transitive : sig
-  type t =
-      {
-	carrier : EConstr.constr;
-	leq : EConstr.constr;
-	transitive : EConstr.constr;
-      }
-  val make : EConstr.constr -> EConstr.constr -> EConstr.constr -> t
-  val infer : goal_sigma -> EConstr.constr -> EConstr.constr -> t  * goal_sigma
-  val from_relation : goal_sigma -> Relation.t -> t * goal_sigma
-  val cps_from_relation : Relation.t -> (t -> Proofview.V82.tac) -> Proofview.V82.tac
-  val to_relation : t -> Relation.t
-end
 	
 module Equivalence : sig
   type t =
@@ -142,7 +116,6 @@ module Equivalence : sig
   val make  : EConstr.constr -> EConstr.constr -> EConstr.constr -> t
   val infer  : goal_sigma -> EConstr.constr -> EConstr.constr -> t  * goal_sigma
   val from_relation : goal_sigma -> Relation.t -> t * goal_sigma
-  val cps_from_relation : Relation.t -> (t -> Proofview.V82.tac) -> Proofview.V82.tac
   val to_relation : t -> Relation.t
   val split : t -> EConstr.constr * EConstr.constr * EConstr.constr
 end

--- a/src/theory.ml
+++ b/src/theory.ml
@@ -29,46 +29,36 @@ open Debug
   (* TODO module HMap = Hashtbl, du coup ? *)
 module HMap = Hashtbl.Make(Constr)
 
-let ac_theory_path = ["AAC_tactics"; "AAC"]
-let ac_util_path = ["AAC_tactics"; "Utils"]
-
 module Stubs = struct
-  let path = ac_theory_path@["Internal"]
 
   (** The constants from the inductive type *)
-  let _Tty = lazy (Coq.init_constant path "T")
+  let _Tty = Coq.find_global "internal.T"
 
-  let rsum = lazy (Coq.init_constant path "sum")
-  let rprd = lazy (Coq.init_constant path "prd")
-  let rsym = lazy (Coq.init_constant path "sym")
-  let runit = lazy (Coq.init_constant path "unit")
+  let rsum = Coq.find_global "internal.sum"
+  let rprd = Coq.find_global "internal.prd"
+  let rsym = Coq.find_global "internal.sym"
+  let runit = Coq.find_global "internal.unit"
 
-  let vnil = lazy (Coq.init_constant path "vnil")
-  let vcons = lazy (Coq.init_constant path "vcons")
-  let eval = lazy (Coq.init_constant path "eval")
+  let vnil = Coq.find_global "internal.vnil"
+  let vcons = Coq.find_global "internal.vcons"
+  let eval = Coq.find_global "internal.eval"
 
 
-  let decide_thm = lazy (Coq.init_constant path "decide")
-  let lift_normalise_thm = lazy (Coq.init_constant path "lift_normalise")
+  let decide_thm = Coq.find_global "internal.decide"
+  let lift_normalise_thm = Coq.find_global "internal.lift_normalise"
 
-  let lift =
-    lazy (Coq.init_constant ac_theory_path "AAC_lift")
-  let lift_proj_equivalence=
-    lazy (Coq.init_constant ac_theory_path "aac_lift_equivalence")
-  let lift_transitivity_left =
-    lazy(Coq.init_constant ac_theory_path "lift_transitivity_left")
-  let lift_transitivity_right =
-    lazy(Coq.init_constant ac_theory_path "lift_transitivity_right")
-  let lift_reflexivity =
-    lazy(Coq.init_constant ac_theory_path "lift_reflexivity")
+  let lift = Coq.find_global "internal.AAC_lift"
+  let lift_proj_equivalence= Coq.find_global "internal.aac_lift_equivalence"
+  let lift_transitivity_left = Coq.find_global "internal.lift_transitivity_left"
+  let lift_transitivity_right = Coq.find_global "internal.lift_transitivity_right"
+  let lift_reflexivity = Coq.find_global "internal.lift_reflexivity"
 end
 
 module Classes = struct
   module Associative = struct
-    let path = ac_theory_path
-    let typ = lazy (Coq.init_constant path "Associative")
+    let typ = Coq.find_global "classes.Associative"
     let ty (rlt : Coq.Relation.t) (value : constr) =
-      mkApp (Lazy.force typ, [| rlt.Coq.Relation.carrier;
+      mkApp (Coq.get_efresh typ, [| rlt.Coq.Relation.carrier;
 				rlt.Coq.Relation.r;
 				value
 			     |] )
@@ -78,10 +68,9 @@ module Classes = struct
   end
 
   module Commutative = struct
-    let path = ac_theory_path
-    let typ = lazy (Coq.init_constant path "Commutative")
+    let typ = Coq.find_global "classes.Commutative"
     let ty (rlt : Coq.Relation.t) (value : constr) =
-      mkApp (Lazy.force typ, [| rlt.Coq.Relation.carrier;
+      mkApp (Coq.get_efresh typ, [| rlt.Coq.Relation.carrier;
 				rlt.Coq.Relation.r;
 				value
 			     |] )
@@ -89,15 +78,14 @@ module Classes = struct
   end
 
   module Proper = struct
-    let path = ac_theory_path @ ["Internal";"Sym"]
-    let typeof = lazy (Coq.init_constant path "type_of")
-    let relof = lazy (Coq.init_constant path "rel_of")
+    let typeof =  Coq.find_global "internal.sym.type_of"
+    let relof = Coq.find_global "internal.sym.rel_of"
     let mk_typeof :  Coq.Relation.t -> int -> constr = fun rlt n ->
       let x = rlt.Coq.Relation.carrier in
-	mkApp (Lazy.force typeof, [| x ; Coq.Nat.of_int n |])
+	mkApp (Coq.get_efresh typeof, [| x ; of_constr (Coq.Nat.of_int n) |])
     let mk_relof :  Coq.Relation.t -> int -> constr = fun rlt n ->
       let (x,r) = Coq.Relation.split rlt in
-      mkApp (Lazy.force relof, [| x;r ; Coq.Nat.of_int n |])
+      mkApp (Coq.get_efresh relof, [| x;r ; of_constr (Coq.Nat.of_int n) |])
 
     let ty rlt op ar  =
       let typeof = mk_typeof rlt ar in
@@ -109,10 +97,9 @@ module Classes = struct
   end
 
   module Unit = struct
-    let path = ac_theory_path
-    let typ = lazy (Coq.init_constant path "Unit")
+    let typ = Coq.find_global "classes.Unit"
     let ty (rlt : Coq.Relation.t) (value : constr) (unit : constr)=
-      mkApp (Lazy.force typ, [| rlt.Coq.Relation.carrier;
+      mkApp (Coq.get_efresh typ, [| rlt.Coq.Relation.carrier;
  				rlt.Coq.Relation.r;
  				value;
  				unit
@@ -123,13 +110,12 @@ end
 
 (* Non empty lists *)
 module NEList = struct
-  let path = ac_util_path
-  let nil = lazy (Coq.init_constant path "nil")
-  let cons = lazy (Coq.init_constant path "cons")
+  let nil = Coq.find_global "nelist.nil"
+  let cons = Coq.find_global "nelist.cons"
   let cons ty h t =
-    mkApp (Lazy.force cons, [|  ty; h ; t |])
+    mkApp (Coq.get_efresh cons, [|  ty; h ; t |])
   let nil ty x =
-    (mkApp (Lazy.force nil, [|  ty ; x|]))
+    (mkApp (Coq.get_efresh nil, [|  ty ; x|]))
   let rec of_list ty = function
     | [] -> invalid_arg "NELIST"
     | [x] -> nil ty x
@@ -139,11 +125,11 @@ end
 
 (** a [mset] is a ('a * pos) list *)
 let mk_mset ty (l : (constr * int) list) =
-  let pos = Lazy.force Coq.Pos.typ in
+  let pos = Coq.get_efresh Coq.Pos.typ in
   let pair (x : constr) (ar : int) =
     Coq.Pair.of_pair ty pos (x, Coq.Pos.of_int ar)
   in
-  let pair_ty = Coq.lapp Coq.Pair.typ [| ty ; pos|] in
+  let pair_ty = mkApp (Coq.get_efresh Coq.Pair.typ,[| ty ; pos|]) in
   let rec aux = function
     | [ ] -> assert false
     | [x,ar] -> NEList.nil pair_ty (pair x ar)
@@ -152,17 +138,17 @@ let mk_mset ty (l : (constr * int) list) =
     aux l
 
 module Sigma = struct
-  let sigma_empty = lazy (Coq.init_constant ac_theory_path "sigma_empty")
-  let sigma_add = lazy (Coq.init_constant ac_theory_path "sigma_add")
-  let sigma_get = lazy (Coq.init_constant ac_theory_path "sigma_get")
+  let sigma_empty = Coq.find_global "sigma.empty"
+  let sigma_add = Coq.find_global "sigma.add"
+  let sigma_get = Coq.find_global "sigma.get"
 
   let add ty n x map =
-    mkApp (Lazy.force sigma_add,[|ty; n; x ;  map|])
+    mkApp (Coq.get_efresh sigma_add,[|ty; n; x ;  map|])
   let empty ty =
-    mkApp (Lazy.force sigma_empty,[|ty |])
+    mkApp (Coq.get_efresh sigma_empty,[|ty |])
 
   let to_fun ty null map =
-    mkApp (Lazy.force sigma_get, [|ty;null;map|])
+    mkApp (Coq.get_efresh sigma_get, [|ty;null;map|])
 
   let of_list ty null l =
     match l with
@@ -183,21 +169,20 @@ end
 
 module Sym = struct
   type pack = {ar: Constr.t; value: Constr.t ; morph: Constr.t}
-  let path = ac_theory_path @ ["Internal";"Sym"]
-  let typ = lazy (Coq.init_constant path "pack")
-  let mkPack = lazy (Coq.init_constant path "mkPack")
-  let null = lazy (Coq.init_constant path "null")
+  let typ = Coq.find_global "sym.pack"
+  let mkPack = Coq.find_global "sym.mkPack"
+  let null = Coq.find_global "sym.null"
   let mk_pack (rlt: Coq.Relation.t) s =
     let (x,r) = Coq.Relation.split rlt in
-      mkApp (Lazy.force mkPack, [|x;r; EConstr.of_constr s.ar;EConstr.of_constr s.value;EConstr.of_constr s.morph|])
+      mkApp (Coq.get_efresh mkPack, [|x;r; EConstr.of_constr s.ar;EConstr.of_constr s.value;EConstr.of_constr s.morph|])
   let null  rlt =
     let x = rlt.Coq.Relation.carrier in
     let r = rlt.Coq.Relation.r in
-      mkApp (Lazy.force null, [| x;r;|])
+      mkApp (Coq.get_efresh null, [| x;r;|])
 
   let mk_ty : Coq.Relation.t -> constr = fun rlt ->
     let (x,r) = Coq.Relation.split rlt in
-      mkApp (Lazy.force typ, [| x; r|] )
+      mkApp (Coq.get_efresh typ, [| x; r|] )
 end
 
 module Bin =struct
@@ -207,14 +192,13 @@ module Bin =struct
 	       comm : Constr.t option;
 	      }
 
-  let path = ac_theory_path @ ["Internal";"Bin"]
-  let typ = lazy (Coq.init_constant path "pack")
-  let mkPack = lazy (Coq.init_constant path "mk_pack")
+  let typ = Coq.find_global "bin.pack"
+  let mkPack = Coq.find_global "bin.mkPack"
 
   let mk_pack: Coq.Relation.t -> pack -> constr = fun (rlt) s ->
     let (x,r) = Coq.Relation.split rlt in
     let comm_ty = Classes.Commutative.ty rlt (EConstr.of_constr s.value) in
-    mkApp (Lazy.force mkPack , [| x ; r;
+    mkApp (Coq.get_efresh mkPack , [| x ; r;
 				  EConstr.of_constr s.value;
 				  EConstr.of_constr s.compat ;
 				  EConstr.of_constr s.assoc;
@@ -222,15 +206,14 @@ module Bin =struct
 			       |])
   let mk_ty : Coq.Relation.t -> constr = fun rlt ->
    let (x,r) = Coq.Relation.split rlt in
-      mkApp (Lazy.force typ, [| x; r|] )
+      mkApp (Coq.get_efresh typ, [| x; r|] )
 end
 
 module Unit = struct
-  let path = ac_theory_path @ ["Internal"]
-  let unit_of_ty = lazy (Coq.init_constant path "unit_of")
-  let unit_pack_ty = lazy (Coq.init_constant path "unit_pack")
-  let mk_unit_of = lazy (Coq.init_constant path "mk_unit_for")
-  let mk_unit_pack = lazy (Coq.init_constant path "mk_unit_pack")
+  let unit_of_ty = Coq.find_global "internal.unit_of"
+  let unit_pack_ty = Coq.find_global "internal.unit_pack"
+  let mk_unit_of = Coq.find_global "internal.mk_unit_for"
+  let mk_unit_pack = Coq.find_global "internal.mk_unit_pack"
 
   type unit_of =
       {
@@ -246,15 +229,15 @@ module Unit = struct
 
   let ty_unit_of rlt  e_bin u =
     let (x,r) = Coq.Relation.split rlt in
-      mkApp ( Lazy.force unit_of_ty, [| x; r; e_bin; u |])
+      mkApp ( Coq.get_efresh unit_of_ty, [| x; r; e_bin; u |])
 
   let ty_unit_pack rlt e_bin =
     let (x,r) = Coq.Relation.split rlt in
-      mkApp (Lazy.force unit_pack_ty, [| x; r; e_bin |])
+      mkApp (Coq.get_efresh unit_pack_ty, [| x; r; e_bin |])
 
   let mk_unit_of rlt e_bin u unit_of =
     let (x,r) = Coq.Relation.split rlt in
-    mkApp (Lazy.force mk_unit_of , [| x;
+    mkApp (Coq.get_efresh mk_unit_of , [| x;
 				      r;
 				      e_bin ;
 				      u;
@@ -267,7 +250,7 @@ module Unit = struct
     let ty = ty_unit_of rlt e_bin pack.u_value in
     let mk_unit_of = mk_unit_of rlt e_bin pack.u_value in
     let u_desc =Coq.List.of_list ( ty ) (List.map mk_unit_of pack.u_desc) in
-      mkApp (Lazy.force mk_unit_pack, [|x;r;
+      mkApp (Coq.get_efresh mk_unit_pack, [|x;r;
 			       e_bin ;
 			       pack.u_value;
 			       u_desc
@@ -519,7 +502,7 @@ module Trans = struct
       let m = Coq.Classes.mk_morphism  typeof relof  papp in
 	try
 	  let sigma,m= Typeclasses.resolve_one_typeclass env sigma m in
-	  let pack = {Sym.ar = EConstr.to_constr sigma (Coq.Nat.of_int ar);
+	  let pack = {Sym.ar = Coq.Nat.of_int ar;
                       Sym.value= EConstr.to_constr sigma papp;
                       Sym.morph= EConstr.to_constr sigma m} in
 	    Some (sigma, Sym pack)
@@ -614,7 +597,7 @@ module Trans = struct
 	let m = Coq.Classes.mk_morphism  typeof relof  papp in
 	try
 	  let sigma,m = Typeclasses.resolve_one_typeclass env sigma m in
-	  let pack = {Sym.ar = EConstr.to_constr ~abort_on_undefined_evars:(false) sigma (Coq.Nat.of_int ar);
+	  let pack = {Sym.ar = Coq.Nat.of_int ar;
                       Sym.value= EConstr.to_constr ~abort_on_undefined_evars:(false) sigma papp;
                       Sym.morph= EConstr.to_constr ~abort_on_undefined_evars:(false) sigma m} in
 	  Some (sigma, Sym pack)
@@ -1048,7 +1031,7 @@ module Trans = struct
       | n  -> let n = n-1 in
 	  mkApp( vcons,
  		 [|
-		   (Coq.Nat.of_int n);
+		   of_constr (Coq.Nat.of_int n);
 		   v.(ar - 1 - n);
 		   (aux (n))
 		 |]
@@ -1061,12 +1044,12 @@ module Trans = struct
     let r = (rlt.Coq.Relation.r) in
 
     let x_r_env = [|x;r;env_sym|] in
-    let tty =  mkApp (Lazy.force Stubs._Tty, x_r_env) in
-    let rsum = mkApp (Lazy.force Stubs.rsum, x_r_env) in
-    let rprd = mkApp (Lazy.force Stubs.rprd, x_r_env) in
-    let rsym = mkApp (Lazy.force Stubs.rsym, x_r_env) in
-    let vnil = mkApp (Lazy.force Stubs.vnil, x_r_env) in
-    let vcons = mkApp (Lazy.force Stubs.vcons, x_r_env) in
+    let tty =  mkApp (Coq.get_efresh Stubs._Tty, x_r_env) in
+    let rsum = mkApp (Coq.get_efresh Stubs.rsum, x_r_env) in
+    let rprd = mkApp (Coq.get_efresh Stubs.rprd, x_r_env) in
+    let rsym = mkApp (Coq.get_efresh Stubs.rsym, x_r_env) in
+    let vnil = mkApp (Coq.get_efresh Stubs.vnil, x_r_env) in
+    let vcons = mkApp (Coq.get_efresh Stubs.vcons, x_r_env) in
     let open Proofview.Notations in
     Coq.mk_letin "tty" tty >>= fun tty ->
     Coq.mk_letin "rsum" rsum >>= fun rsum ->
@@ -1090,7 +1073,7 @@ module Trans = struct
 	  mkApp (rsym, [| idx; vect|])
 	  end;
 	runit = fun idx -> 	(* could benefit of a letin *)
-	        mkApp (Lazy.force Stubs.runit , [|x;r;env_sym;idx; |])
+	        mkApp (Coq.get_efresh Stubs.runit , [|x;r;env_sym;idx; |])
       }
 
 

--- a/src/theory.mli
+++ b/src/theory.mli
@@ -18,7 +18,8 @@
     (either using the Coq "raw" terms, as written in the starting
     goal, or using the reified Coq datatypes we define in {i
     AAC_rewrite.v}).
-*)
+ *)
+open Coq
 
 (** Both in OCaml and Coq, we represent finite multisets using
     weighted lists ([('a*int) list]), see {!Matcher.mset}.
@@ -53,7 +54,7 @@ sig
   (** mimics the Coq record [Sym.pack] *)
   type pack = {ar: Constr.t; value: Constr.t ; morph: Constr.t}
 
-  val typ: EConstr.constr lazy_t
+  val typ: lazy_ref
 
 
   (** [mk_pack rlt (ar,value,morph)]  *)
@@ -68,21 +69,21 @@ end
 (** We need to export some Coq stubs out of this module. They are used
     by the main tactic, see {!Rewrite} *)
 module Stubs : sig
-  val lift : EConstr.constr Lazy.t
-  val lift_proj_equivalence : EConstr.constr Lazy.t
-  val lift_transitivity_left : EConstr.constr Lazy.t
-  val lift_transitivity_right : EConstr.constr Lazy.t
-  val lift_reflexivity : EConstr.constr Lazy.t
+  val lift : lazy_ref
+  val lift_proj_equivalence : lazy_ref
+  val lift_transitivity_left : lazy_ref
+  val lift_transitivity_right : lazy_ref
+  val lift_reflexivity : lazy_ref
 
     (** The evaluation fonction, used to convert a reified coq term to a
 	raw coq term *)
-  val eval: EConstr.constr lazy_t
+  val eval: lazy_ref
 
   (** The main lemma of our theory, that is
       [compare (norm u) (norm v) = Eq -> eval u == eval v] *)
-  val decide_thm:EConstr.constr lazy_t
+  val decide_thm: lazy_ref
 
-  val lift_normalise_thm : EConstr.constr lazy_t
+  val lift_normalise_thm : lazy_ref
 end
 
 (** {2 Building reified terms}

--- a/theories/AAC.v
+++ b/theories/AAC.v
@@ -33,7 +33,7 @@ Require Import RelationClasses Equality.
 Require Export Morphisms.
 
 From AAC_tactics
-Require Import Utils.
+Require Import Utils Constants.
 
 Set Implicit Arguments.
 Set Asymmetric Patterns.
@@ -51,6 +51,10 @@ Section sigma.
     end.
   Definition sigma_add := @PositiveMap.add.
   Definition sigma_empty := @PositiveMap.empty.
+
+  Register sigma_get as aac_tactics.sigma.get.
+  Register sigma_add as aac_tactics.sigma.add.
+  Register sigma_empty as aac_tactics.sigma.empty.
 End sigma.
 
 
@@ -63,7 +67,10 @@ Class Commutative (X:Type) (R: relation X) (plus: X -> X -> X) :=
 Class Unit (X:Type) (R:relation X) (op : X -> X -> X) (unit:X) := {
   law_neutral_left: forall x, R (op unit x) x;
   law_neutral_right: forall x, R (op x unit) x
-}.
+                                                               }.
+Register Associative as aac_tactics.classes.Associative.
+Register Commutative as aac_tactics.classes.Commutative.
+Register Unit as aac_tactics.classes.Unit.
 
 
 (** Class used to find the equivalence relation on which operations
@@ -72,7 +79,9 @@ Class Unit (X:Type) (R:relation X) (op : X -> X -> X) (unit:X) := {
 Class AAC_lift X (R: relation X) (E : relation X) := {
   aac_lift_equivalence : Equivalence E;
   aac_list_proper : Proper (E ==> E ==> iff) R
-}.
+                                                    }.
+Register AAC_lift as aac_tactics.internal.AAC_lift.
+Register aac_lift_equivalence as aac_tactics.internal.aac_lift_equivalence.
 
 (** simple instances, when we have a subrelation, or an equivalence *)
 
@@ -149,6 +158,9 @@ Module Sym.
         | O => R
       | S n => respectful R (rel_of n)
       end.
+
+    Register type_of as aac_tactics.internal.sym.type_of.
+    Register rel_of as aac_tactics.internal.sym.rel_of.
    
   (** a symbol package contains an arity,
      a value of the corresponding type,
@@ -158,11 +170,16 @@ Module Sym.
     ar : nat;
     value :> type_of  ar;
     morph : Proper (rel_of ar) value
-  }.
+                           }.
+
+  Register pack as aac_tactics.sym.pack.
+  Register mkPack as aac_tactics.sym.mkPack.
+
 
   (** helper to build default values, when filling reification environments *)
   Definition null: pack := mkPack 1 (fun x => x) (fun _ _ H => H).
-   
+  Register null as aac_tactics.sym.null.
+
   End t.
 
 End Sym.
@@ -179,7 +196,10 @@ Module Bin.
       compat: Proper (R ==> R ==> R) value;
       assoc: Associative R value;
       comm: option (Commutative R value)
-    }.
+                     }.
+    
+    Register pack as aac_tactics.bin.pack.
+    Register mk_pack as aac_tactics.bin.mkPack.
   End t.
   (*    See #<a href="Instances.html">Instances.v</a># for concrete instances of these classes. *)
 
@@ -210,7 +230,14 @@ Section s.
   Record unit_pack := mk_unit_pack {
     u_value:> X;
     u_desc: list (unit_of u_value)
-  }.
+                        }.
+
+  Register unit_of as aac_tactics.internal.unit_of.
+  Register mk_unit_for as aac_tactics.internal.mk_unit_for.
+  Register unit_pack as aac_tactics.internal.unit_pack.
+  Register mk_unit_pack as aac_tactics.internal.mk_unit_pack.
+
+  
   Variable e_unit: positive -> unit_pack.
  
   Hint Resolve e_bin e_unit: typeclass_instances.
@@ -238,6 +265,14 @@ Section s.
   | vnil: vT O
   | vcons: forall n, T -> vT n -> vT (S n).
 
+  Register T as aac_tactics.internal.T.
+  Register sum as aac_tactics.internal.sum.
+  Register prd as aac_tactics.internal.prd.
+  Register sym as aac_tactics.internal.sym.
+  Register unit as aac_tactics.internal.unit.
+
+  Register vnil as aac_tactics.internal.vnil.
+  Register vcons as aac_tactics.internal.vcons.
 
   (** lexicographic rpo over the normalised syntax *)
   Fixpoint compare (u v: T) :=
@@ -279,6 +314,9 @@ Section s.
       | vnil => fun f => f
       | vcons _ u v => fun f => eval_aux v (f (eval u))
     end.
+
+  Register eval as aac_tactics.internal.eval.
+
 
   (** we need to show that compare reflects equality (this is because
      we work with msets rather than lists with arities) *)
@@ -872,11 +910,13 @@ Section s.
 
   Lemma decide: forall (u v: T), compare (norm u) (norm v) = Eq -> eval u == eval v.
   Proof. intros u v H. apply normalise. apply compare_reflect_eq. apply H. Qed.
+  Register decide as aac_tactics.internal.decide.
 
   Lemma lift_normalise {S} {H : AAC_lift S R}:
     forall (u v: T), (let x := norm u in let y := norm v in
       S (eval x) (eval y)) -> S (eval u) (eval v).
   Proof. destruct H. intros u v; simpl; rewrite 2 eval_norm. trivial. Qed.
+  Register lift_normalise as aac_tactics.internal.lift_normalise.
 
 End s.
 End Internal.
@@ -901,6 +941,10 @@ Section t.
 
   Lemma lift_reflexivity {HR :Reflexive R}: forall x y, E x y -> R x y.
   Proof. destruct H. intros ? ? G. rewrite G. reflexivity. Qed.
+
+  Register lift_transitivity_left as aac_tactics.internal.lift_transitivity_left.
+  Register lift_transitivity_right as aac_tactics.internal.lift_transitivity_right.
+  Register lift_reflexivity as aac_tactics.internal.lift_reflexivity.
 
 End t.
        

--- a/theories/Constants.v
+++ b/theories/Constants.v
@@ -1,0 +1,28 @@
+Register Init.Datatypes.O as aac_tactics.nat.O.
+Register Init.Datatypes.S as aac_tactics.nat.S.
+Register Init.Datatypes.nat as aac_tactics.nat.type.
+
+Register Init.Datatypes.pair as aac_tactics.pair.pair.
+Register Init.Datatypes.prod as aac_tactics.pair.prod.
+
+Register Init.Datatypes.option as aac_tactics.option.typ.
+Register Init.Datatypes.Some as aac_tactics.option.Some.
+Register Init.Datatypes.None as aac_tactics.option.None.
+
+Register Init.Datatypes.list as aac_tactics.list.typ.
+Register Init.Datatypes.nil as aac_tactics.list.nil.
+Register Init.Datatypes.cons as aac_tactics.list.cons.
+
+Require BinNums.
+Register BinNums.positive as aac_tactics.pos.typ.
+Register BinNums.xI as aac_tactics.pos.xI.
+Register BinNums.xO as aac_tactics.pos.xO.
+Register BinNums.xH as aac_tactics.pos.xH.
+
+Require Coq.Classes.Morphisms.
+Register Morphisms.Proper as aac_tactics.coq.classes.morphisms.Proper.
+Require Coq.Classes.RelationClasses.
+
+Register RelationClasses.Equivalence as aac_tactics.coq.RelationClasses.Equivalence.
+Register RelationClasses.Reflexive as aac_tactics.coq.RelationClasses.Reflexive.
+Register RelationClasses.Transitive as aac_tactics.coq.RelationClasses.Transitive.

--- a/theories/Utils.v
+++ b/theories/Utils.v
@@ -104,6 +104,10 @@ Inductive nelist (A : Type) : Type :=
 | nil : A -> nelist A
 | cons : A -> nelist A -> nelist A.
 
+Register nil as aac_tactics.nelist.nil.
+Register cons as aac_tactics.nelist.cons.
+
+
 Notation "x :: y" := (cons x y).
 
 Fixpoint nelist_map (A B: Type) (f: A -> B) l :=


### PR DESCRIPTION
Binding of ocaml-code to coq constants is now via "Register.".

This closes #35 and removes all warnings.

Also I removed some unneeded constants.

Theoretically, this PR lowers the performance by a tiny bit as we now store GlobalRefs instead of storing EConstr (so there is less structure sharing), but this should not matter. 