### PR TITLE
Coq PR #12768 adds a new warning on named catch-all pattern-matching variables

### DIFF
--- a/theories/AAC.v
+++ b/theories/AAC.v
@@ -398,7 +398,7 @@ Section s.
     match u with
       | sum j l => if eq_idx_bool j i then Is_op l else Is_nothing
       | unit j => if is_unit j   then Is_unit j else Is_nothing
-      | u => Is_nothing
+      | _ => Is_nothing
     end.
 
     Definition copy_mset n (l: mset T): mset T :=
@@ -446,7 +446,7 @@ Section s.
     match u with
       | prd j l => if eq_idx_bool j i then Is_op l else Is_nothing
       | unit j => if is_unit j  then Is_unit j else Is_nothing
-      | u => Is_nothing
+      | _ => Is_nothing
     end.
  
    


### PR DESCRIPTION
We address by anticipation the new coq/coq#12768 warning (aac-tactics has default warnings on).

It is backward-compatible and can be merged now.