### PR TITLE
Adapt to Coq PR#13143: Pp.h does not take a (dummy) integer anymore.

### DIFF
--- a/src/print.ml
+++ b/src/print.ml
@@ -38,7 +38,7 @@ let pp_envm pt : named_env Search_monad.m -> Pp.t = fun m ->
   let _,s =
     Search_monad.fold
       (fun env (n,acc) ->
-	 n+1,  h 0 (str (Printf.sprintf "%i:\t[" n) ++pp_env pt env ++ str "]") ++ fnl () :: acc
+	 n+1,  h (str (Printf.sprintf "%i:\t[" n) ++pp_env pt env ++ str "]") ++ fnl () :: acc
       ) m (0,[])
   in
     List.fold_left (fun acc s -> s ++ acc) (str "") (s)


### PR DESCRIPTION
PR coq/coq#13143 proposes to clarify that the integer argument of `Pp.h` boxes is irrelevant. There was one use of `Pp.h` in aac-tactics which called it with a value 0. I interpreted this as really wanting an h-box (without indentation). Not absolutely sure of the original intent of the code though.

To be merged synchronously with coq/coq#13143.