### PR TITLE
Update nix-action to latest version of the new template.

### DIFF
--- a/.github/workflows/nix-action.yml
+++ b/.github/workflows/nix-action.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coq_version:
-          - 'master'
+        overrides:
+          - 'coq = "master"'
       fail-fast: false
     steps:
       - uses: cachix/install-nix-action@v12
@@ -34,4 +34,4 @@ jobs:
           name: math-comp
       - uses: actions/checkout@v2
       - run: >
-          nix-build https://coq.inria.fr/nix/toolbox --argstr job aac-tactics --arg override '{coq = "'${{ matrix.coq_version }}'"; aac-tactics = builtins.filterSource (path: _: baseNameOf path != ".git") ./.;}'
+          nix-build https://coq.inria.fr/nix/toolbox --argstr job aac-tactics --arg override '{ ${{ matrix.overrides }}; aac-tactics = builtins.filterSource (path: _: baseNameOf path != ".git") ./.; }'


### PR DESCRIPTION
The goal of this update is to support testing development versions for projects with extra Coq dependencies. I'm opening this PR to test that it still works as before for `aac-tactics` (it shouldn't have any effect). I will also need to remove the Travis CI file when testing is complete.