### PR TITLE
Test a new setup to deploy to Cachix even for PR from forks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 This file was generated from `meta.yml`, please do not edit manually.
 Follow the instructions on https://github.com/coq-community/templates to regenerate.
 --->
-# AAC Tactics
 
 [![Docker CI][docker-action-shield]][docker-action-link]
 [![Nix CI][nix-action-shield]][nix-action-link]


### PR DESCRIPTION
The explanation can be found in the commit pushed to the `pull-request-target` branch:

>Use the `pull_request_target` event instead of the `pull_request` event to deploy to have access to secret environment variables in all cases. We now skip the `actions/checkout@v2` step because it wouldn't check out the correct commit. This is safe (no risk of linking the secret variables) even with untrusted code because `nix-build` will build it in an isolated environment.

I'm opening this fake PR to test the behavior it gives for a PR from a fork (does it report a CI status like it would for a `pull_request` event? EDIT: yes, it does, with a slightly different name).