### PR TITLE
call tclRETYPE for lift_reflexivity

### DIFF
--- a/src/aac_rewrite.ml
+++ b/src/aac_rewrite.ml
@@ -232,7 +232,8 @@ let aac_reflexivity : unit Proofview.tactic =
         mkApp (Coq.get_efresh (Theory.Stubs.lift_reflexivity),
 	       [| x; r; lift.e.Coq.Equivalence.eq; lift.lift; reflexive |])
       in
-      Unsafe.tclEVARS sigma 
+      Unsafe.tclEVARS sigma
+      <*> Coq.tclRETYPE lift_reflexivity
       <*> Tactics.apply lift_reflexivity
       <*> (let concl = Goal.concl goal in
            tclEVARMAP >>= fun sigma ->

--- a/theories/Tutorial.v
+++ b/theories/Tutorial.v
@@ -432,7 +432,7 @@ Section Lists.
   Import List Permutation.
   Import Instances.Lists.
 
-  Variables (X : Set) (l1 l2 l3 : list X).
+  Variables (X : Type) (l1 l2 l3 : list X).
 
   Goal l1 ++ (l2 ++ l3) = (l1 ++ l2) ++ l3.
     aac_reflexivity.


### PR DESCRIPTION
Fixes #85.

Based on advise from @herbelin, I add a call to `tclRETYPE` for the `lift_reflexivity` lemma at the OCaml level.

@herbelin does this diff look reasonable to you?