### PR TITLE
consistent naming scheme for instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ such as for binary integer arithmetic and booleans, are provided with the plugin
   - Karl Palmskog ([**@palmskog**](https://github.com/palmskog))
 - License: [GNU Lesser General Public License v3.0 or later](LICENSE)
 - Compatible Coq versions: master (use the corresponding branch or release for other Coq versions)
-- Compatible OCaml versions: 4.05.0 or later
+- Compatible OCaml versions: 4.09.0 or later
 - Additional dependencies: none
 - Coq namespace: `AAC_tactics`
 - Related publication(s):
@@ -109,22 +109,24 @@ The file [Instances.v](theories/Instances.v) defines several type class instance
 for frequent use-cases of this plugin, that should allow you to use it off-the-shelf.
 Namely, it contains instances for:
 
-- Peano naturals	(`Import Instances.Peano.`)
-- Z binary numbers	(`Import Instances.Z.`)
-- Lists    		(`Import Instances.Lists.`)
-- N binary numbers	(`Import Instances.N.`)
-- P binary numbers	(`Import Instances.P.`)
-- Rational numbers	(`Import Instances.Q.`)
-- Prop    		(`Import Instances.Prop_ops.`)
-- Booleans		(`Import Instances.Bool.`)
-- Relations		(`Import Instances.Relations.`)
-- all of the above	(`Import Instances.All.`)
-
-See also the [latest coqdoc
-documentation](https://coq-community.org/aac-tactics/docs/coqdoc/toc.html).
+- Peano naturals (`Import Instances.Peano.`)
+- Z binary numbers (`Import Instances.Z.`)
+- Lists (`Import Instances.Lists.`)
+- N binary numbers (`Import Instances.N.`)
+- Positive binary numbers (`Import Instances.P.`)
+- Rational numbers (`Import Instances.Q.`)
+- Prop (`Import Instances.Prop_ops.`)
+- Booleans (`Import Instances.Bool.`)
+- Relations (`Import Instances.Relations.`)
+- all of the above (`Import Instances.All.`)
 
 To understand the inner workings of the tactics, please refer to
 the `.mli` files as the main source of information on each `.ml` file.
+
+See also the [latest coqdoc
+documentation](https://coq-community.org/aac-tactics/docs/coqdoc/toc.html)
+and the [latest ocamldoc
+documentation](https://coq-community.org/aac-tactics/docs/ocamldoc/index.html).
 
 ## Acknowledgements
 

--- a/meta.yml
+++ b/meta.yml
@@ -109,25 +109,27 @@ documentation: |
   for frequent use-cases of this plugin, that should allow you to use it off-the-shelf.
   Namely, it contains instances for:
   
-  - Peano naturals	(`Import Instances.Peano.`)
-  - Z binary numbers	(`Import Instances.Z.`)
-  - Lists    		(`Import Instances.Lists.`)
-  - N binary numbers	(`Import Instances.N.`)
-  - P binary numbers	(`Import Instances.P.`)
-  - Rational numbers	(`Import Instances.Q.`)
-  - Prop    		(`Import Instances.Prop_ops.`)
-  - Booleans		(`Import Instances.Bool.`)
-  - Relations		(`Import Instances.Relations.`)
-  - all of the above	(`Import Instances.All.`)
-
-  See also the [latest coqdoc
-  documentation](https://coq-community.org/aac-tactics/docs/coqdoc/toc.html).
+  - Peano naturals (`Import Instances.Peano.`)
+  - Z binary numbers (`Import Instances.Z.`)
+  - Lists (`Import Instances.Lists.`)
+  - N binary numbers (`Import Instances.N.`)
+  - Positive binary numbers (`Import Instances.P.`)
+  - Rational numbers (`Import Instances.Q.`)
+  - Prop (`Import Instances.Prop_ops.`)
+  - Booleans (`Import Instances.Bool.`)
+  - Relations (`Import Instances.Relations.`)
+  - all of the above (`Import Instances.All.`)
   
   To understand the inner workings of the tactics, please refer to
   the `.mli` files as the main source of information on each `.ml` file.
+
+  See also the [latest coqdoc
+  documentation](https://coq-community.org/aac-tactics/docs/coqdoc/toc.html)
+  and the [latest ocamldoc
+  documentation](https://coq-community.org/aac-tactics/docs/ocamldoc/index.html).
   
   ## Acknowledgements
-  
+
   The initial authors are grateful to Evelyne Contejean, Hugo Herbelin,
   Assia Mahboubi, and Matthieu Sozeau for highly instructive discussions.
   The plugin took inspiration from the plugin tutorial "constructors" by

--- a/theories/Instances.v
+++ b/theories/Instances.v
@@ -21,31 +21,31 @@ Module Peano.
 
   (** ** Peano instances *)
 
-  #[export] Instance aac_add_Assoc : Associative eq Nat.add := Nat.add_assoc.
-  #[export] Instance aac_add_Comm : Commutative eq Nat.add := Nat.add_comm.
+  #[export] Instance aac_Nat_add_Assoc : Associative eq Nat.add := Nat.add_assoc.
+  #[export] Instance aac_Nat_add_Comm : Commutative eq Nat.add := Nat.add_comm.
 
-  #[export] Instance aac_mul_Comm : Commutative eq Nat.mul := Nat.mul_comm.
-  #[export] Instance aac_mul_Assoc : Associative eq Nat.mul := Nat.mul_assoc.
- 
-  #[export] Instance aac_min_Comm : Commutative eq Nat.min := Nat.min_comm.
-  #[export] Instance aac_min_Assoc : Associative eq Nat.min := Nat.min_assoc.
-  #[export] Instance aac_min_Idem : Idempotent eq Nat.min := Nat.min_idempotent.
+  #[export] Instance aac_Nat_mul_Comm : Commutative eq Nat.mul := Nat.mul_comm.
+  #[export] Instance aac_Nat_mul_Assoc : Associative eq Nat.mul := Nat.mul_assoc.
 
-  #[export] Instance aac_max_Comm : Commutative eq Nat.max := Nat.max_comm.
-  #[export] Instance aac_max_Assoc : Associative eq Nat.max := Nat.max_assoc.
-  #[export] Instance aac_max_Idem : Idempotent eq Nat.max := Nat.max_idempotent.
+  #[export] Instance aac_Nat_min_Comm : Commutative eq Nat.min := Nat.min_comm.
+  #[export] Instance aac_Nat_min_Assoc : Associative eq Nat.min := Nat.min_assoc.
+  #[export] Instance aac_Nat_min_Idem : Idempotent eq Nat.min := Nat.min_idempotent.
+
+  #[export] Instance aac_Nat_max_Comm : Commutative eq Nat.max := Nat.max_comm.
+  #[export] Instance aac_Nat_max_Assoc : Associative eq Nat.max := Nat.max_assoc.
+  #[export] Instance aac_Nat_max_Idem : Idempotent eq Nat.max := Nat.max_idempotent.
  
-  #[export] Instance aac_one : Unit eq Nat.mul 1 :=
+  #[export] Instance aac_Nat_mul_1_Unit : Unit eq Nat.mul 1 :=
     Build_Unit eq Nat.mul 1 Nat.mul_1_l Nat.mul_1_r.
-  #[export] Instance aac_zero_add : Unit eq Nat.add O :=
-    Build_Unit eq Nat.add (O) Nat.add_0_l Nat.add_0_r.
-  #[export] Instance aac_zero_max : Unit eq Nat.max  O :=
+  #[export] Instance aac_Nat_add_0_Unit : Unit eq Nat.add 0 :=
+    Build_Unit eq Nat.add (0) Nat.add_0_l Nat.add_0_r.
+  #[export] Instance aac_Nat_max_0_Unit : Unit eq Nat.max 0 :=
     Build_Unit eq Nat.max 0 Nat.max_0_l Nat.max_0_r.
 
-  (** We also provide liftings from  [le] to [eq] *)
-  #[export] Instance preorder_le : PreOrder le :=
+  (** We also provide liftings from  [Nat.le] to [eq] *)
+  #[export] Instance aac_Nat_le_PreOrder : PreOrder Nat.le :=
     Build_PreOrder _ Nat.le_refl Nat.le_trans.
-  #[export] Instance lift_le_eq : AAC_lift le eq :=
+  #[export] Instance aac_Nat_le_eq_lift : AAC_lift Nat.le eq :=
     Build_AAC_lift eq_equivalence _.
 End Peano.
 
@@ -55,29 +55,29 @@ Module Z.
 
   (** ** Z instances *)
 
-  #[export] Instance aac_Zplus_Assoc : Associative eq Zplus := Zplus_assoc.
-  #[export] Instance aac_Zplus_Comm : Commutative eq Zplus := Zplus_comm.
+  #[export] Instance aac_Z_add_Assoc : Associative eq Z.add := Z.add_assoc.
+  #[export] Instance aac_Z_add_Comm : Commutative eq Z.add := Z.add_comm.
  
-  #[export] Instance aac_Zmult_Comm : Commutative eq Zmult := Zmult_comm.
-  #[export] Instance aac_Zmult_Assoc : Associative eq Zmult := Zmult_assoc.
+  #[export] Instance aac_Z_mul_Comm : Commutative eq Z.mul := Z.mul_comm.
+  #[export] Instance aac_Z_mul_Assoc : Associative eq Z.mul := Z.mul_assoc.
  
-  #[export] Instance aac_Zmin_Comm : Commutative eq Z.min := Z.min_comm.
-  #[export] Instance aac_Zmin_Assoc : Associative eq Z.min := Z.min_assoc.
-  #[export] Instance aac_Zmin_Idem : Idempotent eq Z.min := Z.min_idempotent.
+  #[export] Instance aac_Z_min_Comm : Commutative eq Z.min := Z.min_comm.
+  #[export] Instance aac_Z_min_Assoc : Associative eq Z.min := Z.min_assoc.
+  #[export] Instance aac_Z_min_Idem : Idempotent eq Z.min := Z.min_idempotent.
 
-  #[export] Instance aac_Zmax_Comm : Commutative eq Z.max := Z.max_comm.
-  #[export] Instance aac_Zmax_Assoc : Associative eq Z.max := Z.max_assoc.
-  #[export] Instance aac_Zmax_Idem : Idempotent eq Z.max := Z.max_idempotent.
+  #[export] Instance aac_Z_max_Comm : Commutative eq Z.max := Z.max_comm.
+  #[export] Instance aac_Z_max_Assoc : Associative eq Z.max := Z.max_assoc.
+  #[export] Instance aac_Z_max_Idem : Idempotent eq Z.max := Z.max_idempotent.
  
-  #[export] Instance aac_one : Unit eq Zmult 1 :=
-    Build_Unit eq Zmult 1 Zmult_1_l Zmult_1_r.
-  #[export] Instance aac_zero_Zplus : Unit eq Zplus 0 :=
-    Build_Unit eq Zplus 0 Zplus_0_l Zplus_0_r.
+  #[export] Instance aac_Z_mul_1_Unit : Unit eq Z.mul 1 :=
+    Build_Unit eq Z.mul 1 Z.mul_1_l Z.mul_1_r.
+  #[export] Instance aac_Z_add_0_Unit : Unit eq Z.add 0 :=
+    Build_Unit eq Z.add 0 Z.add_0_l Z.add_0_r.
 
   (** We also provide liftings from [Z.le] to [eq] *)
-  #[export] Instance preorder_Zle : PreOrder Z.le :=
+  #[export] Instance aac_Z_le_preorder : PreOrder Z.le :=
     Build_PreOrder _ Z.le_refl Z.le_trans.
-  #[export] Instance lift_le_eq : AAC_lift Z.le eq :=
+  #[export] Instance aac_Z_le_eq_lift : AAC_lift Z.le eq :=
     Build_AAC_lift eq_equivalence _.
 End Z.
 
@@ -86,17 +86,17 @@ Module Lists.
 
   (** ** List instances *)
 
-  #[export] Instance aac_append_Assoc {A} : Associative eq (@app A) :=
+  #[export] Instance aac_List_app_Assoc {A} : Associative eq (@app A) :=
     @app_assoc A.
-  #[export] Instance aac_nil_append  {A} : Unit eq (@app A) (@nil A) :=
+  #[export] Instance aac_List_app_nil_Unit  {A} : Unit eq (@app A) (@nil A) :=
     Build_Unit _ (@app A) (@nil A) (@app_nil_l A) (@app_nil_r A).
   (** Exported [Morphisms] module provides a [Proper] instance *)
 
-  #[export] Instance aac_append_Permutation_Assoc {A} : Associative (@Permutation A) (@app A).
+  #[export] Instance aac_List_app_Permutation_Assoc {A} : Associative (@Permutation A) (@app A).
   Proof. repeat intro; rewrite app_assoc; apply Permutation_refl. Qed.
-  #[export] Instance aac_append_Permutation_Comm {A} : Commutative (@Permutation A) (@app A) :=
+  #[export] Instance aac_List_app_Permutation_Comm {A} : Commutative (@Permutation A) (@app A) :=
     @Permutation_app_comm A.
-  #[export] Instance aac_nil_Permutation_append {A} : Unit (@Permutation A) (@app A) (@nil A) :=
+  #[export] Instance aac_List_app_nil_Permutation_Unit {A} : Unit (@Permutation A) (@app A) (@nil A) :=
     Build_Unit (@Permutation A) (@app A) (@nil A) (fun x => Permutation_refl x)
      (fun x => eq_ind_r (fun l => Permutation l _) (Permutation_refl x) (app_nil_r x)).
   (** [Permutation_app'] in the Stdlib provides a [Proper] instance *)
@@ -108,31 +108,31 @@ Module N.
 
   (** ** N instances *)
 
-  #[export] Instance aac_Nplus_Assoc : Associative eq Nplus := Nplus_assoc.
-  #[export] Instance aac_Nplus_Comm : Commutative eq Nplus := Nplus_comm.
- 
-  #[export] Instance aac_Nmult_Comm : Commutative eq Nmult := Nmult_comm.
-  #[export] Instance aac_Nmult_Assoc : Associative eq Nmult := Nmult_assoc.
- 
-  #[export] Instance aac_Nmin_Comm : Commutative eq N.min := N.min_comm.
-  #[export] Instance aac_Nmin_Assoc : Associative eq N.min := N.min_assoc.
-  #[export] Instance aac_Nmin_Idem : Idempotent eq N.min := N.min_idempotent.
+  #[export] Instance aac_N_add_Assoc : Associative eq N.add := N.add_assoc.
+  #[export] Instance aac_N_add_Comm : Commutative eq N.add := N.add_comm.
 
-  #[export] Instance aac_Nmax_Comm : Commutative eq N.max := N.max_comm.
-  #[export] Instance aac_Nmax_Assoc : Associative eq N.max := N.max_assoc.
-  #[export] Instance aac_Nmax_Idem : Idempotent eq N.max := N.max_idempotent.
- 
-  #[export] Instance aac_one : Unit eq Nmult (1)%N :=
-    Build_Unit eq Nmult (1)%N Nmult_1_l Nmult_1_r.
-  #[export] Instance aac_zero : Unit eq Nplus (0)%N :=
-    Build_Unit eq Nplus (0)%N Nplus_0_l Nplus_0_r.
-  #[export] Instance aac_zero_max : Unit eq N.max 0 :=
+  #[export] Instance aac_N_mul_Comm : Commutative eq N.mul := N.mul_comm.
+  #[export] Instance aac_N_mul_Assoc : Associative eq N.mul := N.mul_assoc.
+
+  #[export] Instance aac_N_min_Comm : Commutative eq N.min := N.min_comm.
+  #[export] Instance aac_N_min_Assoc : Associative eq N.min := N.min_assoc.
+  #[export] Instance aac_N_min_Idem : Idempotent eq N.min := N.min_idempotent.
+
+  #[export] Instance aac_N_max_Comm : Commutative eq N.max := N.max_comm.
+  #[export] Instance aac_N_max_Assoc : Associative eq N.max := N.max_assoc.
+  #[export] Instance aac_N_max_Idem : Idempotent eq N.max := N.max_idempotent.
+
+  #[export] Instance aac_N_mul_1_Unit : Unit eq N.mul (1)%N :=
+    Build_Unit eq N.mul (1)%N N.mul_1_l N.mul_1_r.
+  #[export] Instance aac_N_add_0_Unit : Unit eq N.add (0)%N :=
+    Build_Unit eq N.add (0)%N N.add_0_l N.add_0_r.
+  #[export] Instance aac_N_max_0_Unit : Unit eq N.max 0 :=
     Build_Unit eq N.max 0 N.max_0_l N.max_0_r.
-   
+
   (* We also provide liftings from [N.le] to [eq] *)
-  #[export] Instance preorder_le : PreOrder N.le :=
+  #[export] Instance aac_N_le_PreOrder : PreOrder N.le :=
     Build_PreOrder N.le N.le_refl N.le_trans.
-  #[export] Instance lift_le_eq : AAC_lift N.le eq :=
+  #[export] Instance aac_N_le_eq_lift : AAC_lift N.le eq :=
     Build_AAC_lift eq_equivalence _.
 End N.
 
@@ -142,33 +142,29 @@ Module P.
 
   (** ** Positive instances *)
 
-  #[export] Instance aac_Pplus_Assoc : Associative eq Pplus := Pplus_assoc.
-  #[export] Instance aac_Pplus_Comm : Commutative eq Pplus := Pplus_comm.
- 
-  #[export] Instance aac_Pmult_Comm : Commutative eq Pmult := Pmult_comm.
-  #[export] Instance aac_Pmult_Assoc : Associative eq Pmult := Pmult_assoc.
- 
-  #[export] Instance aac_Pmin_Comm : Commutative eq Pos.min := Pos.min_comm.
-  #[export] Instance aac_Pmin_Assoc : Associative eq Pos.min := Pos.min_assoc.
-  #[export] Instance aac_Pmin_Idem : Idempotent eq Pos.min := Pos.min_idempotent.
+  #[export] Instance aac_Pos_add_Assoc : Associative eq Pos.add := Pos.add_assoc.
+  #[export] Instance aac_Pos_add_Comm : Commutative eq Pos.add := Pos.add_comm.
 
-  #[export] Instance aac_Pmax_Comm : Commutative eq Pos.max := Pos.max_comm.
-  #[export] Instance aac_Pmax_Assoc : Associative eq Pos.max := Pos.max_assoc.
-  #[export] Instance aac_Pmax_Idem : Idempotent eq Pos.max := Pos.max_idempotent.
+  #[export] Instance aac_Pos_mul_Comm : Commutative eq Pos.mul := Pos.mul_comm.
+  #[export] Instance aac_Pos_mul_Assoc : Associative eq Pos.mul := Pos.mul_assoc.
 
-  (* TODO: add this lemma in the stdlib *)
-  Lemma Pmult_1_l (x : positive) : 1 * x = x.
-  Proof. reflexivity. Qed.
+  #[export] Instance aac_Pos_min_Comm : Commutative eq Pos.min := Pos.min_comm.
+  #[export] Instance aac_Pos_min_Assoc : Associative eq Pos.min := Pos.min_assoc.
+  #[export] Instance aac_Pos_min_Idem : Idempotent eq Pos.min := Pos.min_idempotent.
 
-  #[export] Instance aac_one : Unit eq Pmult 1 :=
-    Build_Unit eq Pmult 1 Pmult_1_l Pmult_1_r.
-  #[export] Instance aac_one_max : Unit eq Pos.max 1 :=
+  #[export] Instance aac_Pos_max_Comm : Commutative eq Pos.max := Pos.max_comm.
+  #[export] Instance aac_Pos_max_Assoc : Associative eq Pos.max := Pos.max_assoc.
+  #[export] Instance aac_Pos_max_Idem : Idempotent eq Pos.max := Pos.max_idempotent.
+
+  #[export] Instance aac_Pos_mul_1_Unit : Unit eq Pos.mul 1 :=
+    Build_Unit eq Pos.mul 1 Pos.mul_1_l Pos.mul_1_r.
+  #[export] Instance aac_Pos_max_1_Unit : Unit eq Pos.max 1 :=
     Build_Unit eq Pos.max 1 Pos.max_1_l Pos.max_1_r.
 
   (** We also provide liftings from [Pos.le] to [eq] *)
-  #[export] Instance preorder_le : PreOrder Pos.le :=
+  #[export] Instance aac_Pos_le_PreOrder : PreOrder Pos.le :=
     Build_PreOrder Pos.le Pos.le_refl Pos.le_trans.
-  #[export] Instance lift_le_eq : AAC_lift Pos.le eq :=
+  #[export] Instance aac_Pos_le_eq_lift : AAC_lift Pos.le eq :=
     Build_AAC_lift eq_equivalence _.
 End P.
 
@@ -177,53 +173,53 @@ Module Q.
 
   (** ** Q instances *)
 
-  #[export] Instance aac_Qplus_Assoc : Associative Qeq Qplus := Qplus_assoc.
-  #[export] Instance aac_Qplus_Comm : Commutative Qeq Qplus := Qplus_comm.
- 
-  #[export] Instance aac_Qmult_Comm : Commutative Qeq Qmult := Qmult_comm.
-  #[export] Instance aac_Qmult_Assoc : Associative Qeq Qmult := Qmult_assoc.
- 
-  #[export] Instance aac_Qmin_Comm : Commutative Qeq Qmin := Q.min_comm.
-  #[export] Instance aac_Qmin_Assoc : Associative Qeq Qmin := Q.min_assoc.
-  #[export] Instance aac_Qmin_Idem : Idempotent Qeq Qmin := Q.min_idempotent.
+  #[export] Instance aac_Q_Qplus_Qeq_Assoc : Associative Qeq Qplus := Qplus_assoc.
+  #[export] Instance aac_Q_Qplus_Qeq_Comm : Commutative Qeq Qplus := Qplus_comm.
 
-  #[export] Instance aac_Qmax_Comm : Commutative Qeq Qmax := Q.max_comm.
-  #[export] Instance aac_Qmax_Assoc : Associative Qeq Qmax := Q.max_assoc.
-  #[export] Instance aac_Qmax_Idem : Idempotent Qeq Qmax := Q.max_idempotent.
- 
-  #[export] Instance aac_one : Unit Qeq Qmult 1 := 
-    Build_Unit Qeq Qmult 1 Qmult_1_l Qmult_1_r. 
-  #[export] Instance aac_zero_Qplus  : Unit Qeq Qplus 0 :=
+  #[export] Instance aac_Q_Qmult_Qeq_Comm : Commutative Qeq Qmult := Qmult_comm.
+  #[export] Instance aac_Q_Qmult_Qeq_Assoc : Associative Qeq Qmult := Qmult_assoc.
+
+  #[export] Instance aac_Q_Qmin_Qeq_Comm : Commutative Qeq Qmin := Q.min_comm.
+  #[export] Instance aac_Q_Qmin_Qeq_Assoc : Associative Qeq Qmin := Q.min_assoc.
+  #[export] Instance aac_Q_Qmin_Qeq_Idem : Idempotent Qeq Qmin := Q.min_idempotent.
+
+  #[export] Instance aac_Q_Qmax_Qeq_Comm : Commutative Qeq Qmax := Q.max_comm.
+  #[export] Instance aac_Q_Qmax_Qeq_Assoc : Associative Qeq Qmax := Q.max_assoc.
+  #[export] Instance aac_Q_Qmax_Qeq_Idem : Idempotent Qeq Qmax := Q.max_idempotent.
+
+  #[export] Instance aac_Q_Qmult_1_Qeq_Unit : Unit Qeq Qmult 1 :=
+    Build_Unit Qeq Qmult 1 Qmult_1_l Qmult_1_r.
+  #[export] Instance aac_Q_Qplus_0_Qeq_Unit : Unit Qeq Qplus 0 :=
     Build_Unit Qeq Qplus 0 Qplus_0_l Qplus_0_r.
 
   (** we also provide liftings from le to eq *)
-  #[export] Instance preorder_le : PreOrder Qle :=
+  #[export] Instance aac_Q_Qle_PreOrder : PreOrder Qle :=
     Build_PreOrder Qle Qle_refl Qle_trans.
-  #[export] Instance lift_le_eq : AAC_lift Qle Qeq :=
+  #[export] Instance aac_Q_Qle_eq_lift : AAC_lift Qle Qeq :=
     Build_AAC_lift QOrderedType.QOrder.TO.eq_equiv _.
 End Q.
 
 Module Prop_ops.
   (** ** Prop instances *)
 
-  #[export] Instance aac_or_Assoc : Associative iff or.
+  #[export] Instance aac_Prop_or_iff_Assoc : Associative iff or.
   Proof. unfold Associative; tauto. Qed.
-  #[export] Instance aac_or_Comm : Commutative iff or.
+  #[export] Instance aac_Prop_or_iff_Comm : Commutative iff or.
   Proof. unfold Commutative; tauto. Qed.
-  #[export] Instance aac_or_Idem : Idempotent iff or.
+  #[export] Instance aac_Prop_or_iff_Idem : Idempotent iff or.
   Proof. unfold Idempotent; tauto. Qed.
-  #[export] Instance aac_and_Idem : Idempotent iff and.
+  #[export] Instance aac_Prop_and_iff_Idem : Idempotent iff and.
   Proof. unfold Idempotent; tauto. Qed.
-  #[export] Instance aac_True : Unit iff or False.
+  #[export] Instance aac_Prop_or_False_iff_Unit : Unit iff or False.
   Proof. constructor; firstorder. Qed.
-  #[export] Instance aac_False : Unit iff and True.
+  #[export] Instance aac_Prop_and_True_iff_Unit : Unit iff and True.
   Proof. constructor; firstorder. Qed.
  
-  #[export] Program Instance aac_not_compat : Proper (iff ==> iff) not.
+  #[export] Program Instance not_iff_compat : Proper (iff ==> iff) not.
   Next Obligation. unfold iff; split; intros; tauto. Qed.
 
   Solve All Obligations with firstorder.
-  #[export] Instance lift_impl_iff : AAC_lift Basics.impl iff :=
+  #[export] Instance aac_Prop_impl_iff_lift : AAC_lift Basics.impl iff :=
     Build_AAC_lift _  _.
 End Prop_ops.
 
@@ -231,21 +227,21 @@ Module Bool.
 
   (** ** Boolean instances *)
 
-  #[export] Instance aac_orb_Assoc : Associative eq orb.
+  #[export] Instance aac_Bool_orb_Assoc : Associative eq orb.
   Proof. unfold Associative; firstorder with bool. Qed.
-  #[export] Instance aac_orb_Comm : Commutative eq orb.
+  #[export] Instance aac_Bool_orb_Comm : Commutative eq orb.
   Proof. unfold Commutative; firstorder with bool. Qed.
-  #[export] Instance aac_orb_Idem : Idempotent eq orb.
+  #[export] Instance aac_Bool_orb_Idem : Idempotent eq orb.
   Proof. intro; apply Bool.orb_diag. Qed.
-  #[export] Instance aac_andb_Assoc : Associative eq andb.
+  #[export] Instance aac_Bool_andb_Assoc : Associative eq andb.
   Proof. unfold Associative; firstorder with bool. Qed.
-  #[export] Instance aac_andb_Comm : Commutative eq andb.
+  #[export] Instance aac_Bool_andb_Comm : Commutative eq andb.
   Proof. unfold Commutative; firstorder with bool. Qed.
-  #[export] Instance aac_andb_Idem : Idempotent eq andb.
+  #[export] Instance aac_Bool_andb_Idem : Idempotent eq andb.
   Proof. intro; apply Bool.andb_diag. Qed.
-  #[export] Instance aac_true : Unit eq orb false.
+  #[export] Instance aac_Bool_orb_false_Unit : Unit eq orb false.
   Proof. constructor; firstorder with bool. Qed.
-  #[export] Instance aac_false : Unit eq andb true.
+  #[export] Instance aac_Bool_andb_true_Unit : Unit eq andb true.
   Proof. constructor; intros [|]; firstorder. Qed.
   #[export] Instance negb_compat : Proper (eq ==> eq) negb.
   Proof. intros [|] [|]; auto. Qed.
@@ -267,38 +263,49 @@ Module Relations.
     Definition top : relation T := fun _ _ => True.
   End defs.
  
-  #[export] Instance eq_same_relation T : Equivalence (same_relation T).
+  #[export] Instance same_relation_Equivalence T :
+    Equivalence (same_relation T).
   Proof. firstorder. Qed.
  
-  #[export] Instance aac_union_Comm T : Commutative (same_relation T) (union T).
+  #[export] Instance aac_union_same_relation_Comm T :
+    Commutative (same_relation T) (union T).
   Proof. unfold Commutative; compute; intuition. Qed.
-  #[export] Instance aac_union_Assoc T : Associative (same_relation T) (union T).
+  #[export] Instance aac_union_same_relation_Assoc T :
+    Associative (same_relation T) (union T).
   Proof. unfold Associative; compute; intuition. Qed.
-  #[export] Instance aac_union_Idem T : Idempotent (same_relation T) (union T).
+  #[export] Instance aac_union_same_relation_Idem T :
+    Idempotent (same_relation T) (union T).
   Proof. unfold Idempotent; compute; intuition. Qed.
-  #[export] Instance aac_bot T : Unit (same_relation T) (union T) (bot T).
+  #[export] Instance aac_bot_union_same_relation_Unit T :
+    Unit (same_relation T) (union T) (bot T).
   Proof. constructor; compute; intuition. Qed.
 
-  #[export] Instance aac_inter_Comm T : Commutative (same_relation T) (inter T).
+  #[export] Instance aac_inter_same_relation_Comm T :
+    Commutative (same_relation T) (inter T).
   Proof. unfold Commutative; compute; intuition. Qed.
-  #[export] Instance aac_inter_Assoc T : Associative (same_relation T) (inter T).
-  Proof. unfold Associative; compute; intuition.  Qed.
-  #[export] Instance aac_inter_Idem T : Idempotent (same_relation T) (inter T).
+  #[export] Instance aac_inter_same_relation_Assoc T :
+    Associative (same_relation T) (inter T).
+  Proof. unfold Associative; compute; intuition. Qed.
+  #[export] Instance aac_inter_same_relation_Idem T :
+    Idempotent (same_relation T) (inter T).
   Proof. unfold Idempotent; compute; intuition. Qed.
-  #[export] Instance aac_top T : Unit (same_relation T) (inter T) (top T).
+  #[export] Instance aac_inter_top_same_relation_Unit T :
+    Unit (same_relation T) (inter T) (top T).
   Proof. constructor; compute; intuition. Qed.
  
   (** Note that we use [eq] directly as a neutral element for composition *)
-  #[export] Instance aac_compo T : Associative (same_relation T) (compo T).
+  #[export] Instance aac_compo_same_relation_Assoc T :
+    Associative (same_relation T) (compo T).
   Proof. unfold Associative; compute; firstorder. Qed.
-  #[export] Instance aac_eq T : Unit (same_relation T) (compo T) (eq).
+  #[export] Instance aac_compo_eq_same_relation_Unit T :
+    Unit (same_relation T) (compo T) (eq).
   Proof. compute; firstorder subst; trivial. Qed.
 
-  #[export] Instance negr_compat T :
+  #[export] Instance negr_same_relation_compat T :
    Proper (same_relation T ==> same_relation T) (negr T).
   Proof. compute. firstorder. Qed.
 
-  #[export] Instance transp_compat T :
+  #[export] Instance transp_same_relation_compat T :
    Proper (same_relation T ==> same_relation T) (transp T).
   Proof. compute. firstorder. Qed.
 
@@ -310,7 +317,7 @@ Module Relations.
     econstructor 2; eauto 3.
   Qed.
 
-  #[export] Instance clos_trans_compat T :
+  #[export] Instance clos_trans_same_relation_compat T :
    Proper (same_relation T ==> same_relation T) (clos_trans T).
   Proof. intros R S H; split; apply clos_trans_incr, H. Qed.
 
@@ -323,16 +330,16 @@ Module Relations.
     econstructor 3; eauto 3.
   Qed.
 
-  #[export] Instance clos_refl_trans_compat T :
+  #[export] Instance clos_refl_trans_same_relation_compat T :
     Proper (same_relation T ==> same_relation T) (clos_refl_trans T).
   Proof. intros R S H; split; apply clos_refl_trans_incr, H. Qed.
 
-  #[export] Instance preorder_inclusion T : PreOrder (inclusion T).
+  #[export] Instance inclusion_PreOrder T : PreOrder (inclusion T).
   Proof. constructor; unfold Reflexive, Transitive, inclusion; intuition. Qed.
 
-  #[export] Program Instance lift_inclusion_same_relation T :
+  #[export] Program Instance aac_inclusion_same_relation_lift T :
    AAC_lift (inclusion T) (same_relation T) :=
-    Build_AAC_lift (eq_same_relation T) _.
+    Build_AAC_lift (same_relation_Equivalence T) _.
   Next Obligation. firstorder. Qed.
 End Relations.
 

--- a/theories/Instances.v
+++ b/theories/Instances.v
@@ -43,7 +43,7 @@ Module Peano.
     Build_Unit eq Nat.max 0 Nat.max_0_l Nat.max_0_r.
 
   (** We also provide liftings from  [Nat.le] to [eq] *)
-  #[export] Instance aac_Nat_le_PreOrder : PreOrder Nat.le :=
+  #[export] Instance Nat_le_PreOrder : PreOrder Nat.le :=
     Build_PreOrder _ Nat.le_refl Nat.le_trans.
   #[export] Instance aac_Nat_le_eq_lift : AAC_lift Nat.le eq :=
     Build_AAC_lift eq_equivalence _.
@@ -75,7 +75,7 @@ Module Z.
     Build_Unit eq Z.add 0 Z.add_0_l Z.add_0_r.
 
   (** We also provide liftings from [Z.le] to [eq] *)
-  #[export] Instance aac_Z_le_preorder : PreOrder Z.le :=
+  #[export] Instance Z_le_PreOrder : PreOrder Z.le :=
     Build_PreOrder _ Z.le_refl Z.le_trans.
   #[export] Instance aac_Z_le_eq_lift : AAC_lift Z.le eq :=
     Build_AAC_lift eq_equivalence _.
@@ -130,7 +130,7 @@ Module N.
     Build_Unit eq N.max 0 N.max_0_l N.max_0_r.
 
   (* We also provide liftings from [N.le] to [eq] *)
-  #[export] Instance aac_N_le_PreOrder : PreOrder N.le :=
+  #[export] Instance N_le_PreOrder : PreOrder N.le :=
     Build_PreOrder N.le N.le_refl N.le_trans.
   #[export] Instance aac_N_le_eq_lift : AAC_lift N.le eq :=
     Build_AAC_lift eq_equivalence _.
@@ -162,7 +162,7 @@ Module P.
     Build_Unit eq Pos.max 1 Pos.max_1_l Pos.max_1_r.
 
   (** We also provide liftings from [Pos.le] to [eq] *)
-  #[export] Instance aac_Pos_le_PreOrder : PreOrder Pos.le :=
+  #[export] Instance Pos_le_PreOrder : PreOrder Pos.le :=
     Build_PreOrder Pos.le Pos.le_refl Pos.le_trans.
   #[export] Instance aac_Pos_le_eq_lift : AAC_lift Pos.le eq :=
     Build_AAC_lift eq_equivalence _.
@@ -193,7 +193,7 @@ Module Q.
     Build_Unit Qeq Qplus 0 Qplus_0_l Qplus_0_r.
 
   (** we also provide liftings from le to eq *)
-  #[export] Instance aac_Q_Qle_PreOrder : PreOrder Qle :=
+  #[export] Instance Q_Qle_PreOrder : PreOrder Qle :=
     Build_PreOrder Qle Qle_refl Qle_trans.
   #[export] Instance aac_Q_Qle_eq_lift : AAC_lift Qle Qeq :=
     Build_AAC_lift QOrderedType.QOrder.TO.eq_equiv _.


### PR DESCRIPTION
Also, use Stdlib in more consistent way.

Fixes #123 