### PR TITLE
Replace calls to "vm_compute in hyps" by plain calls to vm_compute.

### DIFF
--- a/theories/AAC.v
+++ b/theories/AAC.v
@@ -936,7 +936,9 @@ End Internal.
 
 Local Ltac internal_normalize :=
   let x := fresh in let y := fresh in
-  intro x; intro y; vm_compute in x; vm_compute in y; unfold x; unfold y;
+  intro x; intro y;
+  let vx := eval vm_compute in x in change x with vx;
+  let vy := eval vm_compute in y in change y with vy;
   compute [Internal.eval Utils.fold_map Internal.copy Prect]; simpl.
 
 (** ** Lemmas for performing transitivity steps given an AAC_lift instance *)


### PR DESCRIPTION
The terms are of type `Internal.T env_sym`, so invoking `vm_compute in` on them ends up strongly normalizing the function `env_sym`, which explodes. By using `eval vm_compute` instead, only the bodies get strongly normalized.

This is related to coq/coq#18917.