### PR TITLE
[build] Fix use of plugin aliases in findlib loading.

### DIFF
--- a/theories/AAC.v
+++ b/theories/AAC.v
@@ -960,4 +960,4 @@ Section t.
 
 End t.
        
-Declare ML Module "aac_plugin:coq-aac-tactics.plugin".
+Declare ML Module "coq-aac-tactics.plugin".


### PR DESCRIPTION
Newer Coq will raise a warning here, as the acc_tactics build setup is `-warn-on-error` we do fix this now, backwards compatible.