### PR TITLE
Adapt Makefile to Rocq v9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean: Makefile.coq
 	@rm -f Makefile.coq Makefile.coq.conf
 
 Makefile.coq: _CoqProject
-	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+	$(COQBIN)rocq makefile -f _CoqProject -o Makefile.coq
 
 force _CoqProject Makefile: ;
 

--- a/theories/Tutorial.v
+++ b/theories/Tutorial.v
@@ -403,10 +403,10 @@ Section Examples.
   (** *** Reverse triangle inequality *)
 
   Lemma Z_abs_triangle : forall x y, Z.abs (x + y) <= Z.abs x + Z.abs y.
-  Proof Z.abs_triangle.
+  Proof. exact Z.abs_triangle. Qed.
 
   Lemma Z_add_opp_diag_r : forall x, x + -x = 0.
-  Proof Z.add_opp_diag_r.
+  Proof. exact Z.add_opp_diag_r. Qed.
 
   (** The following morphisms are required to perform the required rewrites: *)
   #[local] Instance Z_opp_ge_le_compat : Proper (Z.ge ==> Z.le) Z.opp.


### PR DESCRIPTION
I don't know about dune building but concerning make building, this seems to be enough to work with Rocq 9 without compatibility shims.
Since the installation [opam file](https://raw.githubusercontent.com/rocq-prover/opam/refs/heads/master/released/packages/coq-aac-tactics/coq-aac-tactics.8.20.0/opam) seems to rely on make building, this should allow then to easily define a rocq-aac-tactics package (for rocq 9.0, and rocq-9.1 soon).